### PR TITLE
feature/SIM-1983/wavefront sensor methods

### DIFF
--- a/python/lsst/sims/GalSimInterface/galSimDetector.py
+++ b/python/lsst/sims/GalSimInterface/galSimDetector.py
@@ -116,7 +116,7 @@ class GalSim_afw_TanSipWCS(galsim.wcs.CelestialWCS):
         if type(ra) is numpy.ndarray:
             chipNameLIst = chipNameList * len(ra)
 
-        xx, yy = calculatePixelCoordinates(ra=ra, dec=dec, chipNames=chipNameList,
+        xx, yy = calculatePixelCoordinates(ra=ra, dec=dec, chipName=chipNameList,
                                             obs_metadata=self.obs_metadata,
                                             epoch=self.epoch,
                                             camera = self.afwCamera)
@@ -265,7 +265,7 @@ class GalSimDetector(object):
             raLocal = numpy.array([ra])
             decLocal = numpy.array([dec])
 
-        xPix, yPix = _pixelCoordsFromRaDec(raLocal, decLocal, chipNames=nameList,
+        xPix, yPix = _pixelCoordsFromRaDec(raLocal, decLocal, chipName=nameList,
                                            obs_metadata=self._obs_metadata,
                                            epoch=self._epoch,
                                            camera=self._afwCamera)
@@ -298,7 +298,7 @@ class GalSimDetector(object):
             xp = numpy.array([xPupil])
             yp = numpy.array([yPupil])
 
-        xPix, yPix = pixelCoordsFromPupilCoords(xp, yp, chipNames=nameList,
+        xPix, yPix = pixelCoordsFromPupilCoords(xp, yp, chipName=nameList,
                                                 camera=self._afwCamera)
 
         return xPix, yPix

--- a/python/lsst/sims/GalSimInterface/galSimDetector.py
+++ b/python/lsst/sims/GalSimInterface/galSimDetector.py
@@ -58,8 +58,8 @@ class GalSim_afw_TanSipWCS(galsim.wcs.CelestialWCS):
         self.fitsHeader.set("EXTTYPE", "IMAGE")
 
         if self.obs_metadata.bandpass is not None:
-            if not isinstance(self.obs_metadata.bandpass, list) and not \
-                isinstance(self.obs_metadata.bandpass, np.ndarray):
+            if (not isinstance(self.obs_metadata.bandpass, list) and not
+                isinstance(self.obs_metadata.bandpass, np.ndarray)):
 
                 self.fitsHeader.set("FILTER", self.obs_metadata.bandpass)
 

--- a/python/lsst/sims/GalSimInterface/galSimDetector.py
+++ b/python/lsst/sims/GalSimInterface/galSimDetector.py
@@ -3,7 +3,7 @@ import galsim
 import numpy
 import lsst.afw.geom as afwGeom
 from lsst.afw.cameraGeom import PUPIL, PIXELS, FOCAL_PLANE
-from lsst.sims.utils import arcsecFromRadians, radiansFromArcsec
+from lsst.sims.utils import arcsecFromRadians
 from lsst.sims.coordUtils import _raDecFromPixelCoords, \
                                  _pixelCoordsFromRaDec, \
                                  pixelCoordsFromPupilCoords
@@ -58,7 +58,9 @@ class GalSim_afw_TanSipWCS(galsim.wcs.CelestialWCS):
         self.fitsHeader.set("EXTTYPE", "IMAGE")
 
         if self.obs_metadata.bandpass is not None:
-            if not isinstance(self.obs_metadata.bandpass, list) and not isinstance(self.obs_metadata.bandpass, numpy.ndarray):
+            if not isinstance(self.obs_metadata.bandpass, list) and not \
+                isinstance(self.obs_metadata.bandpass, numpy.ndarray):
+
                 self.fitsHeader.set("FILTER", self.obs_metadata.bandpass)
 
         if self.obs_metadata.mjd is not None:
@@ -77,7 +79,6 @@ class GalSim_afw_TanSipWCS(galsim.wcs.CelestialWCS):
         self.crval2 = self.fitsHeader.get("CRVAL2")
 
         self.origin = galsim.PositionD(x=self.crpix1, y=self.crpix2)
-
 
     def _radec(self, x, y):
         """
@@ -103,7 +104,6 @@ class GalSim_afw_TanSipWCS(galsim.wcs.CelestialWCS):
         else:
             return (ra[0], dec[0])
 
-
     def _xy(self, ra, dec):
         """
         This is a method required by the GalSim WCS API
@@ -114,18 +114,17 @@ class GalSim_afw_TanSipWCS(galsim.wcs.CelestialWCS):
         chipNameList = [self.afwDetector.getName()]
 
         if type(ra) is numpy.ndarray:
-            chipNameLIst = chipNameList * len(ra)
+            chipNameList = chipNameList * len(ra)
 
-        xx, yy = calculatePixelCoordinates(ra=ra, dec=dec, chipName=chipNameList,
-                                            obs_metadata=self.obs_metadata,
-                                            epoch=self.epoch,
-                                            camera = self.afwCamera)
+        xx, yy = _pixelCoordsFromRaDec(ra=ra, dec=dec, chipName=chipNameList,
+                                       obs_metadata=self.obs_metadata,
+                                       epoch=self.epoch,
+                                       camera = self.afwCamera)
 
         if type(ra) is numpy.ndarray:
             return (xx-self.crpix1, yy-self.crpix2)
         else:
             return (xx[0]-self.crpix1, yy-self.crpix2)
-
 
     def _newOrigin(self, origin):
         """
@@ -147,14 +146,11 @@ class GalSim_afw_TanSipWCS(galsim.wcs.CelestialWCS):
         _newWcs.fitsHeader.set('CRPIX2', origin.y)
         return _newWcs
 
-
     def _writeHeader(self, header, bounds):
         for key in self.fitsHeader.getOrderedNames():
             header[key] = self.fitsHeader.get(key)
 
         return header
-
-
 
 
 class GalSimDetector(object):
@@ -179,7 +175,7 @@ class GalSimDetector(object):
             raise RuntimeError("You need to specify an instantiation of PhotometricParameters " +
                                "when constructing a GalSimDetector")
 
-        self._wcs = None #this will be created when it is actually called for
+        self._wcs = None  # this will be created when it is actually called for
         self._name = afwDetector.getName()
         self._afwDetector = afwDetector
         self._afwCamera = afwCamera
@@ -216,32 +212,29 @@ class GalSimDetector(object):
 
             xx = arcsecFromRadians(cameraPointPupil.getX())
             yy = arcsecFromRadians(cameraPointPupil.getY())
-            if self._xMinArcsec is None or xx<self._xMinArcsec:
+            if self._xMinArcsec is None or xx < self._xMinArcsec:
                 self._xMinArcsec = xx
-            if self._xMaxArcsec is None or xx>self._xMaxArcsec:
+            if self._xMaxArcsec is None or xx > self._xMaxArcsec:
                 self._xMaxArcsec = xx
-            if self._yMinArcsec is None or yy<self._yMinArcsec:
+            if self._yMinArcsec is None or yy < self._yMinArcsec:
                 self._yMinArcsec = yy
-            if self._yMaxArcsec is None or yy>self._yMaxArcsec:
+            if self._yMaxArcsec is None or yy > self._yMaxArcsec:
                 self._yMaxArcsec = yy
-
 
         self._photParams = photParams
         self._fileName = self._getFileName()
-
 
     def _getFileName(self):
         """
         Format the name of the detector to add to the name of the FITS file
         """
         detectorName = self.name
-        detectorName = detectorName.replace(',','_')
-        detectorName = detectorName.replace(':','_')
-        detectorName = detectorName.replace(' ','_')
+        detectorName = detectorName.replace(',', '_')
+        detectorName = detectorName.replace(':', '_')
+        detectorName = detectorName.replace(' ', '_')
 
         name = detectorName
         return name
-
 
     def pixelCoordinatesFromRaDec(self, ra, dec):
         """
@@ -259,8 +252,8 @@ class GalSimDetector(object):
         nameList = [self.name]
         if type(ra) is numpy.ndarray:
             nameList = nameList*len(ra)
-            raLocal=ra
-            decLocal=dec
+            raLocal = ra
+            decLocal = dec
         else:
             raLocal = numpy.array([ra])
             decLocal = numpy.array([dec])
@@ -271,8 +264,6 @@ class GalSimDetector(object):
                                            camera=self._afwCamera)
 
         return xPix, yPix
-
-
 
     def pixelCoordinatesFromPupilCoordinates(self, xPupil, yPupil):
         """
@@ -303,7 +294,6 @@ class GalSimDetector(object):
 
         return xPix, yPix
 
-
     def containsRaDec(self, ra, dec):
         """
         Does a given RA, Dec fall on this detector?
@@ -320,7 +310,6 @@ class GalSimDetector(object):
         points = [afwGeom.Point2D(xx, yy) for xx, yy in zip(xPix, yPix)]
         answer = [self._bbox.contains(pp) for pp in points]
         return answer
-
 
     def containsPupilCoordinates(self, xPupil, yPupil):
         """
@@ -340,7 +329,6 @@ class GalSimDetector(object):
         answer = [self._bbox.contains(pp) for pp in points]
         return answer
 
-
     @property
     def xMinPix(self):
         """Minimum x pixel coordinate of the detector"""
@@ -348,9 +336,8 @@ class GalSimDetector(object):
 
     @xMinPix.setter
     def xMinPix(self, value):
-        raise RuntimeError("You should not be setting xMinPix on the fly; " \
-                           + "just instantiate a new GalSimDetector")
-
+        raise RuntimeError("You should not be setting xMinPix on the fly; "
+                           "just instantiate a new GalSimDetector")
 
     @property
     def xMaxPix(self):
@@ -359,9 +346,8 @@ class GalSimDetector(object):
 
     @xMaxPix.setter
     def xMaxPix(self, value):
-        raise RuntimeError("You should not be setting xMaxPix on the fly; " \
-                           + "just instantiate a new GalSimDetector")
-
+        raise RuntimeError("You should not be setting xMaxPix on the fly; "
+                           "just instantiate a new GalSimDetector")
 
     @property
     def yMinPix(self):
@@ -370,9 +356,8 @@ class GalSimDetector(object):
 
     @yMinPix.setter
     def yMinPix(self, value):
-        raise RuntimeError("You should not be setting yMinPix on the fly; " \
-                           + "just instantiate a new GalSimDetector")
-
+        raise RuntimeError("You should not be setting yMinPix on the fly; "
+                           "just instantiate a new GalSimDetector")
 
     @property
     def yMaxPix(self):
@@ -381,9 +366,8 @@ class GalSimDetector(object):
 
     @yMaxPix.setter
     def yMaxPix(self, value):
-        raise RuntimeError("You should not be setting yMaxPix on the fly; " \
-                           + "just instantiate a new GalSimDetector")
-
+        raise RuntimeError("You should not be setting yMaxPix on the fly; "
+                           "just instantiate a new GalSimDetector")
 
     @property
     def xCenterPix(self):
@@ -392,9 +376,8 @@ class GalSimDetector(object):
 
     @xCenterPix.setter
     def xCenterPix(self, value):
-        raise RuntimeError("You should not be setting xCenterPix on the fly; " \
-                           + "just instantiate a new GalSimDetector")
-
+        raise RuntimeError("You should not be setting xCenterPix on the fly; "
+                           "just instantiate a new GalSimDetector")
 
     @property
     def yCenterPix(self):
@@ -403,9 +386,8 @@ class GalSimDetector(object):
 
     @yCenterPix.setter
     def yCenterPix(self, value):
-        raise RuntimeError("You should not be setting yCenterPix on the fly; " \
-                           + "just instantiate a new GalSimDetector")
-
+        raise RuntimeError("You should not be setting yCenterPix on the fly; "
+                           "just instantiate a new GalSimDetector")
 
     @property
     def xMaxArcsec(self):
@@ -414,9 +396,8 @@ class GalSimDetector(object):
 
     @xMaxArcsec.setter
     def xMaxArcsec(self, value):
-        raise RuntimeError("You should not be setting xMaxArcsec on the fly; " \
-                           + "just instantiate a new GalSimDetector")
-
+        raise RuntimeError("You should not be setting xMaxArcsec on the fly; "
+                           "just instantiate a new GalSimDetector")
 
     @property
     def xMinArcsec(self):
@@ -425,9 +406,8 @@ class GalSimDetector(object):
 
     @xMinArcsec.setter
     def xMinArcsec(self, value):
-        raise RuntimeError("You should not be setting xMinArcsec on the fly; " \
-                           + "just instantiate a new GalSimDetector")
-
+        raise RuntimeError("You should not be setting xMinArcsec on the fly; "
+                           "just instantiate a new GalSimDetector")
 
     @property
     def yMaxArcsec(self):
@@ -436,9 +416,8 @@ class GalSimDetector(object):
 
     @yMaxArcsec.setter
     def yMaxArcsec(self, value):
-        raise RuntimeError("You should not be setting yMaxArcsec on the fly; " \
-                           + "just instantiate a new GalSimDetector")
-
+        raise RuntimeError("You should not be setting yMaxArcsec on the fly; "
+                           "just instantiate a new GalSimDetector")
 
     @property
     def yMinArcsec(self):
@@ -447,21 +426,18 @@ class GalSimDetector(object):
 
     @yMinArcsec.setter
     def yMinArcsec(self, value):
-        raise RuntimeError("You should not be setting yMinArcsec on the fly; " \
-                           + "just instantiate a new GalSimDetector")
-
+        raise RuntimeError("You should not be setting yMinArcsec on the fly; "
+                           "just instantiate a new GalSimDetector")
 
     @property
     def xCenterArcsec(self):
         """Center x pupil coordinate of the detector in arcseconds"""
         return self._xCenterArcsec
 
-
     @xCenterArcsec.setter
     def xCenterArcsec(self, value):
-        raise RuntimeError("You should not be setting xCenterArcsec on the fly; " \
-                           + "just instantiate a new GalSimDetector")
-
+        raise RuntimeError("You should not be setting xCenterArcsec on the fly; "
+                           "just instantiate a new GalSimDetector")
 
     @property
     def yCenterArcsec(self):
@@ -470,9 +446,8 @@ class GalSimDetector(object):
 
     @yCenterArcsec.setter
     def yCenterArcsec(self, value):
-        raise RuntimeError("You should not be setting yCenterArcsec on the fly; " \
-                           + "just instantiate a new GalSimDetector")
-
+        raise RuntimeError("You should not be setting yCenterArcsec on the fly; "
+                           "just instantiate a new GalSimDetector")
 
     @property
     def epoch(self):
@@ -481,9 +456,8 @@ class GalSimDetector(object):
 
     @epoch.setter
     def epoch(self, value):
-        raise RuntimeError("You should not be setting epoch on the fly; " \
-                           + "just instantiate a new GalSimDetector")
-
+        raise RuntimeError("You should not be setting epoch on the fly; "
+                           "just instantiate a new GalSimDetector")
 
     @property
     def obs_metadata(self):
@@ -492,9 +466,8 @@ class GalSimDetector(object):
 
     @obs_metadata.setter
     def obs_metadata(self, value):
-        raise RuntimeError("You should not be setting obs_metadata on the fly; " \
-                           + "just instantiate a new GalSimDetector")
-
+        raise RuntimeError("You should not be setting obs_metadata on the fly; "
+                           "just instantiate a new GalSimDetector")
 
     @property
     def name(self):
@@ -503,9 +476,8 @@ class GalSimDetector(object):
 
     @name.setter
     def name(self, value):
-        raise RuntimeError("You should not be setting name on the fly; " \
-                           + "just instantiate a new GalSimDetector")
-
+        raise RuntimeError("You should not be setting name on the fly; "
+                           "just instantiate a new GalSimDetector")
 
     @property
     def photParams(self):
@@ -514,9 +486,8 @@ class GalSimDetector(object):
 
     @photParams.setter
     def photParams(self, value):
-        raise RuntimeError("You should not be setting photParams on the fly; " \
-                           + "just instantiate a new GalSimDetector")
-
+        raise RuntimeError("You should not be setting photParams on the fly; "
+                           "just instantiate a new GalSimDetector")
 
     @property
     def fileName(self):
@@ -525,9 +496,8 @@ class GalSimDetector(object):
 
     @fileName.setter
     def fileName(self, value):
-        raise RuntimeError("You should not be setting fileName on the fly; "  \
-                           + "just instantiate a new GalSimDetector")
-
+        raise RuntimeError("You should not be setting fileName on the fly; "
+                           "just instantiate a new GalSimDetector")
 
     @property
     def afwCamera(self):
@@ -536,9 +506,8 @@ class GalSimDetector(object):
 
     @afwCamera.setter
     def afwCamera(self, value):
-        raise RuntimeError("You should not be setting afwCamera on the fly; " \
-                           + "just instantiate a new GalSimDetector")
-
+        raise RuntimeError("You should not be setting afwCamera on the fly; "
+                           "just instantiate a new GalSimDetector")
 
     @property
     def afwDetector(self):
@@ -547,23 +516,21 @@ class GalSimDetector(object):
 
     @afwDetector.setter
     def afwDetector(self, value):
-        raise RuntimeError("You should not be setting afwDetector on the fly; " \
-                           + "just instantiate a new GalSimDetector")
-
+        raise RuntimeError("You should not be setting afwDetector on the fly; "
+                           "just instantiate a new GalSimDetector")
 
     @property
     def wcs(self):
         """WCS corresponding to this detector"""
         if self._wcs is None:
-            self._wcs = GalSim_afw_TanSipWCS(self.afwDetector, self.afwCamera, \
+            self._wcs = GalSim_afw_TanSipWCS(self.afwDetector, self.afwCamera,
                                              self.obs_metadata, self.epoch,
                                              photParams=self.photParams)
-
 
             if re.match('R_[0-9]_[0-9]_S_[0-9]_[0-9]', self.fileName) is not None:
                 # This is an LSST camera; format the FITS header to feed through DM code
 
-                wcsName = self.fileName.replace('_','')
+                wcsName = self.fileName.replace('_', '')
                 wcsName = wcsName.replace('S', '_S')
 
                 self._wcs.fitsHeader.set("CHIPID", wcsName)
@@ -572,12 +539,13 @@ class GalSimDetector(object):
 
                 if self.obs_metadata.phoSimMetaData is not None:
                     if 'Opsim_obshistid' in self.obs_metadata.phoSimMetaData:
-                        self._wcs.fitsHeader.set("OBSID", self.obs_metadata.phoSimMetaData['Opsim_obshistid'][0])
+                        self._wcs.fitsHeader.set("OBSID",
+                                                 self.obs_metadata.phoSimMetaData['Opsim_obshistid'][0])
                         obshistid = self.obs_metadata.phoSimMetaData['Opsim_obshistid'][0]
 
                 bp = self.obs_metadata.bandpass
                 if not isinstance(bp, list) and not isinstance(bp, numpy.ndarray):
-                    filt_num = {'u':0, 'g':1, 'r':2, 'i':3, 'z':4, 'y':5}[bp]
+                    filt_num = {'u': 0, 'g': 1, 'r': 2, 'i': 3, 'z': 4, 'y': 5}[bp]
                 else:
                     filt_num = 2
 
@@ -588,6 +556,6 @@ class GalSimDetector(object):
 
     @wcs.setter
     def wcs(self, value):
-        raise RuntimeError("You should not be setting wcs on the fly; " \
-                           + "just instantiate a new GalSimDetector")
+        raise RuntimeError("You should not be setting wcs on the fly; "
+                           "just instantiate a new GalSimDetector")
 

--- a/python/lsst/sims/GalSimInterface/galSimDetector.py
+++ b/python/lsst/sims/GalSimInterface/galSimDetector.py
@@ -1,6 +1,6 @@
 import re
 import galsim
-import numpy
+import numpy as np
 import lsst.afw.geom as afwGeom
 from lsst.afw.cameraGeom import PUPIL, PIXELS, FOCAL_PLANE
 from lsst.sims.utils import arcsecFromRadians
@@ -59,7 +59,7 @@ class GalSim_afw_TanSipWCS(galsim.wcs.CelestialWCS):
 
         if self.obs_metadata.bandpass is not None:
             if not isinstance(self.obs_metadata.bandpass, list) and not \
-                isinstance(self.obs_metadata.bandpass, numpy.ndarray):
+                isinstance(self.obs_metadata.bandpass, np.ndarray):
 
                 self.fitsHeader.set("FILTER", self.obs_metadata.bandpass)
 
@@ -91,7 +91,7 @@ class GalSim_afw_TanSipWCS(galsim.wcs.CelestialWCS):
 
         chipNameList = [self.afwDetector.getName()]
 
-        if type(x) is numpy.ndarray:
+        if type(x) is np.ndarray:
             chipNameList = chipNameList * len(x)
 
         ra, dec = _raDecFromPixelCoords(x + self.afw_crpix1, y + self.afw_crpix2, chipNameList,
@@ -99,7 +99,7 @@ class GalSim_afw_TanSipWCS(galsim.wcs.CelestialWCS):
                                         obs_metadata=self.obs_metadata,
                                         epoch=self.epoch)
 
-        if type(x) is numpy.ndarray:
+        if type(x) is np.ndarray:
             return (ra, dec)
         else:
             return (ra[0], dec[0])
@@ -113,7 +113,7 @@ class GalSim_afw_TanSipWCS(galsim.wcs.CelestialWCS):
 
         chipNameList = [self.afwDetector.getName()]
 
-        if type(ra) is numpy.ndarray:
+        if type(ra) is np.ndarray:
             chipNameList = chipNameList * len(ra)
 
         xx, yy = _pixelCoordsFromRaDec(ra=ra, dec=dec, chipName=chipNameList,
@@ -121,7 +121,7 @@ class GalSim_afw_TanSipWCS(galsim.wcs.CelestialWCS):
                                        epoch=self.epoch,
                                        camera = self.afwCamera)
 
-        if type(ra) is numpy.ndarray:
+        if type(ra) is np.ndarray:
             return (xx-self.crpix1, yy-self.crpix2)
         else:
             return (xx[0]-self.crpix1, yy-self.crpix2)
@@ -250,13 +250,13 @@ class GalSimDetector(object):
         """
 
         nameList = [self.name]
-        if type(ra) is numpy.ndarray:
+        if type(ra) is np.ndarray:
             nameList = nameList*len(ra)
             raLocal = ra
             decLocal = dec
         else:
-            raLocal = numpy.array([ra])
-            decLocal = numpy.array([dec])
+            raLocal = np.array([ra])
+            decLocal = np.array([dec])
 
         xPix, yPix = _pixelCoordsFromRaDec(raLocal, decLocal, chipName=nameList,
                                            obs_metadata=self._obs_metadata,
@@ -281,13 +281,13 @@ class GalSimDetector(object):
         """
 
         nameList = [self._name]
-        if type(xPupil) is numpy.ndarray:
+        if type(xPupil) is np.ndarray:
             nameList = nameList*len(xPupil)
             xp = xPupil
             yp = yPupil
         else:
-            xp = numpy.array([xPupil])
-            yp = numpy.array([yPupil])
+            xp = np.array([xPupil])
+            yp = np.array([yPupil])
 
         xPix, yPix = pixelCoordsFromPupilCoords(xp, yp, chipName=nameList,
                                                 camera=self._afwCamera)
@@ -544,7 +544,7 @@ class GalSimDetector(object):
                         obshistid = self.obs_metadata.phoSimMetaData['Opsim_obshistid'][0]
 
                 bp = self.obs_metadata.bandpass
-                if not isinstance(bp, list) and not isinstance(bp, numpy.ndarray):
+                if not isinstance(bp, list) and not isinstance(bp, np.ndarray):
                     filt_num = {'u': 0, 'g': 1, 'r': 2, 'i': 3, 'z': 4, 'y': 5}[bp]
                 else:
                     filt_num = 2

--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -318,9 +318,9 @@ class GalSimInterpreter(object):
 
                 name = self._getFileName(detector=detector, bandpassName=bandpassName)
 
-                xPix, yPix = pixelCoordsFromPupilCoords(numpy.array([gsObject.xPupilRadians]),
-                                                        numpy.array([gsObject.yPupilRadians]),
-                                                        chipNames=[detector.name],
+                xPix, yPix = pixelCoordsFromPupilCoords(gsObject.xPupilRadians,
+                                                        gsObject.yPupilRadians,
+                                                        chipName=detector.name,
                                                         camera=detector.afwCamera)
 
                 obj = centeredObj.copy()
@@ -330,7 +330,7 @@ class GalSimInterpreter(object):
 
                 self.detectorImages[name] = obj.drawImage(method='phot',
                                                           gain=detector.photParams.gain,
-                                                          offset=galsim.PositionD(xPix[0]-detector.xCenterPix, yPix[0]-detector.yCenterPix),
+                                                          offset=galsim.PositionD(xPix-detector.xCenterPix, yPix-detector.yCenterPix),
                                                           rng=self._rng,
                                                           image=self.detectorImages[name],
                                                           add_to_image=True)

--- a/python/lsst/sims/GalSimInterface/wcsUtils/WcsUtils.py
+++ b/python/lsst/sims/GalSimInterface/wcsUtils/WcsUtils.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 from lsst.sims.coordUtils import _pixelCoordsFromRaDec, _raDecFromPixelCoords
 from lsst.afw.cameraGeom import TAN_PIXELS, FOCAL_PLANE
 import lsst.afw.geom as afwGeom
@@ -75,14 +75,14 @@ def tanWcsFromDetector(afwDetector, afwCamera, obs_metadata, epoch):
     dx = 0.5*(xTanPixMax-xTanPixMin)
     dy = 0.5*(yTanPixMax-yTanPixMin)
 
-    for xx in numpy.arange(xTanPixMin, xTanPixMax+0.5*dx, dx):
-        for yy in numpy.arange(yTanPixMin, yTanPixMax+0.5*dy, dy):
+    for xx in np.arange(xTanPixMin, xTanPixMax+0.5*dx, dx):
+        for yy in np.arange(yTanPixMin, yTanPixMax+0.5*dy, dy):
             xPixList.append(xx)
             yPixList.append(yy)
             nameList.append(afwDetector.getName())
 
-    raList, decList = _raDecFromPixelCoords(numpy.array(xPixList),
-                                            numpy.array(yPixList),
+    raList, decList = _raDecFromPixelCoords(np.array(xPixList),
+                                            np.array(yPixList),
                                             nameList,
                                             camera=afwCamera,
                                             obs_metadata=obs_metadata,
@@ -104,32 +104,32 @@ def tanWcsFromDetector(afwDetector, afwCamera, obs_metadata, epoch):
     #
     # Calabretta and Greisen (2002), A&A 395, p. 1077
     #
-    radiusList = 180.0/(numpy.tan(latList)*numpy.pi)
-    uList = radiusList*numpy.sin(lonList)
-    vList = -radiusList*numpy.cos(lonList)
+    radiusList = 180.0/(np.tan(latList)*np.pi)
+    uList = radiusList*np.sin(lonList)
+    vList = -radiusList*np.cos(lonList)
 
     delta_xList = xPixList - crPix1
     delta_yList = yPixList - crPix2
 
-    bVector = numpy.array([
-                          (delta_xList*uList).sum(),
-                          (delta_yList*uList).sum(),
-                          (delta_xList*vList).sum(),
-                          (delta_yList*vList).sum()
-                          ])
+    bVector = np.array([
+                       (delta_xList*uList).sum(),
+                       (delta_yList*uList).sum(),
+                       (delta_xList*vList).sum(),
+                       (delta_yList*vList).sum()
+                       ])
 
     offDiag = (delta_yList*delta_xList).sum()
-    xsq = numpy.power(delta_xList, 2).sum()
-    ysq = numpy.power(delta_yList, 2).sum()
+    xsq = np.power(delta_xList, 2).sum()
+    ysq = np.power(delta_yList, 2).sum()
 
-    aMatrix = numpy.array([
-                          [xsq, offDiag, 0.0, 0.0],
-                          [offDiag, ysq, 0.0, 0.0],
-                          [0.0, 0.0, xsq, offDiag],
-                          [0.0, 0.0, offDiag, ysq]
-                          ])
+    aMatrix = np.array([
+                       [xsq, offDiag, 0.0, 0.0],
+                       [offDiag, ysq, 0.0, 0.0],
+                       [0.0, 0.0, xsq, offDiag],
+                       [0.0, 0.0, offDiag, ysq]
+                       ])
 
-    coeffs = numpy.linalg.solve(aMatrix, bVector)
+    coeffs = np.linalg.solve(aMatrix, bVector)
 
     fitsHeader = dafBase.PropertyList()
     fitsHeader.set("RADESYS", "ICRS")

--- a/python/lsst/sims/GalSimInterface/wcsUtils/WcsUtils.py
+++ b/python/lsst/sims/GalSimInterface/wcsUtils/WcsUtils.py
@@ -1,6 +1,6 @@
 import numpy
 from lsst.sims.coordUtils import _pixelCoordsFromRaDec, _raDecFromPixelCoords
-from lsst.afw.cameraGeom import PUPIL, PIXELS, TAN_PIXELS, FOCAL_PLANE
+from lsst.afw.cameraGeom import TAN_PIXELS, FOCAL_PLANE
 import lsst.afw.geom as afwGeom
 import lsst.afw.image as afwImage
 import lsst.afw.image.utils as afwImageUtils
@@ -20,19 +20,18 @@ def _getTanPixelBounds(afwDetector, afwCamera):
     yPixMax = None
     cornerPointList = afwDetector.getCorners(FOCAL_PLANE)
     for cornerPoint in cornerPointList:
-        cameraPoint = afwCamera.transform(
-                           afwDetector.makeCameraPoint(cornerPoint, FOCAL_PLANE),
-                           tanPixelSystem).getPoint()
+        cameraPoint = afwCamera.transform(afwDetector.makeCameraPoint(cornerPoint, FOCAL_PLANE),
+                                          tanPixelSystem).getPoint()
 
         xx = cameraPoint.getX()
         yy = cameraPoint.getY()
-        if xPixMin is None or xx<xPixMin:
+        if xPixMin is None or xx < xPixMin:
             xPixMin = xx
-        if xPixMax is None or xx>xPixMax:
+        if xPixMax is None or xx > xPixMax:
             xPixMax = xx
-        if yPixMin is None or yy<yPixMin:
+        if yPixMin is None or yy < yPixMin:
             yPixMin = yy
-        if yPixMax is None or yy>yPixMax:
+        if yPixMax is None or yy > yPixMax:
             yPixMax = yy
 
     return xPixMin, xPixMax, yPixMin, yPixMax
@@ -65,14 +64,13 @@ def tanWcsFromDetector(afwDetector, afwCamera, obs_metadata, epoch):
     xTanPixMin, xTanPixMax, \
     yTanPixMin, yTanPixMax = _getTanPixelBounds(afwDetector, afwCamera)
 
-
     xPixList = []
     yPixList = []
     nameList = []
 
-    #dx and dy are set somewhat heuristically
-    #setting them eqal to 0.1(max-min) lead to errors
-    #on the order of 0.7 arcsec in the WCS
+    # dx and dy are set somewhat heuristically
+    # setting them eqal to 0.1(max-min) lead to errors
+    # on the order of 0.7 arcsec in the WCS
 
     dx = 0.5*(xTanPixMax-xTanPixMin)
     dy = 0.5*(yTanPixMax-yTanPixMin)
@@ -101,10 +99,10 @@ def tanWcsFromDetector(afwDetector, afwCamera, obs_metadata, epoch):
                                                  obs_metadata._pointingRA,
                                                  obs_metadata._pointingDec)
 
-    #convert from native longitude and latitude to intermediate world coordinates
-    #according to equations (12), (13), (54) and (55) of
+    # convert from native longitude and latitude to intermediate world coordinates
+    # according to equations (12), (13), (54) and (55) of
     #
-    #Calabretta and Greisen (2002), A&A 395, p. 1077
+    # Calabretta and Greisen (2002), A&A 395, p. 1077
     #
     radiusList = 180.0/(numpy.tan(latList)*numpy.pi)
     uList = radiusList*numpy.sin(lonList)
@@ -121,8 +119,8 @@ def tanWcsFromDetector(afwDetector, afwCamera, obs_metadata, epoch):
                           ])
 
     offDiag = (delta_yList*delta_xList).sum()
-    xsq = numpy.power(delta_xList,2).sum()
-    ysq = numpy.power(delta_yList,2).sum()
+    xsq = numpy.power(delta_xList, 2).sum()
+    ysq = numpy.power(delta_yList, 2).sum()
 
     aMatrix = numpy.array([
                           [xsq, offDiag, 0.0, 0.0],
@@ -133,18 +131,13 @@ def tanWcsFromDetector(afwDetector, afwCamera, obs_metadata, epoch):
 
     coeffs = numpy.linalg.solve(aMatrix, bVector)
 
-    crValPoint = afwGeom.Point2D(obs_metadata.pointingRA,
-                                 obs_metadata.pointingDec)
-
-    crPixPoint = afwGeom.Point2D(crPix1, crPix2)
-
     fitsHeader = dafBase.PropertyList()
     fitsHeader.set("RADESYS", "ICRS")
     fitsHeader.set("EQUINOX", epoch)
     fitsHeader.set("CRVAL1", obs_metadata.pointingRA)
     fitsHeader.set("CRVAL2", obs_metadata.pointingDec)
-    fitsHeader.set("CRPIX1", crPix1+1) # the +1 is because LSST uses 0-indexed images
-    fitsHeader.set("CRPIX2", crPix2+1) # FITS files use 1-indexed images
+    fitsHeader.set("CRPIX1", crPix1+1)  # the +1 is because LSST uses 0-indexed images
+    fitsHeader.set("CRPIX2", crPix2+1)  # FITS files use 1-indexed images
     fitsHeader.set("CTYPE1", "RA---TAN")
     fitsHeader.set("CTYPE2", "DEC--TAN")
     fitsHeader.setDouble("CD1_1", coeffs[0])
@@ -204,12 +197,12 @@ def tanSipWcsFromDetector(afwDetector, afwCamera, obs_metadata, epoch,
 
     distortedWcs = afwImageUtils.getDistortedWcs(mockExposure.getInfo())
     tanSipWcs = approximateWcs(distortedWcs, bbox,
-                                          order=order,
-                                          skyTolerance=skyToleranceArcSec*afwGeom.arcseconds,
-                                          pixelTolerance=pixelTolerance,
-                                          detector=afwDetector,
-                                          camera=afwCamera,
-                                          obs_metadata=obs_metadata)
+                               order=order,
+                               skyTolerance=skyToleranceArcSec*afwGeom.arcseconds,
+                               pixelTolerance=pixelTolerance,
+                               detector=afwDetector,
+                               camera=afwCamera,
+                               obs_metadata=obs_metadata)
 
     return tanSipWcs
 

--- a/python/lsst/sims/GalSimInterface/wcsUtils/WcsUtils.py
+++ b/python/lsst/sims/GalSimInterface/wcsUtils/WcsUtils.py
@@ -92,9 +92,9 @@ def tanWcsFromDetector(afwDetector, afwCamera, obs_metadata, epoch):
                                             epoch=epoch,
                                             includeDistortion=False)
 
-    crPix1, crPix2 = _pixelCoordsFromRaDec(numpy.array([obs_metadata._pointingRA]),
-                                           numpy.array([obs_metadata._pointingDec]),
-                                           chipNames=[afwDetector.getName()], camera=afwCamera,
+    crPix1, crPix2 = _pixelCoordsFromRaDec(obs_metadata._pointingRA,
+                                           obs_metadata._pointingDec,
+                                           chipName=afwDetector.getName(), camera=afwCamera,
                                            obs_metadata=obs_metadata, epoch=epoch,
                                            includeDistortion=False)
 
@@ -111,8 +111,8 @@ def tanWcsFromDetector(afwDetector, afwCamera, obs_metadata, epoch):
     uList = radiusList*numpy.sin(lonList)
     vList = -radiusList*numpy.cos(lonList)
 
-    delta_xList = xPixList - crPix1[0]
-    delta_yList = yPixList - crPix2[0]
+    delta_xList = xPixList - crPix1
+    delta_yList = yPixList - crPix2
 
     bVector = numpy.array([
                           (delta_xList*uList).sum(),
@@ -137,15 +137,15 @@ def tanWcsFromDetector(afwDetector, afwCamera, obs_metadata, epoch):
     crValPoint = afwGeom.Point2D(obs_metadata.pointingRA,
                                  obs_metadata.pointingDec)
 
-    crPixPoint = afwGeom.Point2D(crPix1[0], crPix2[0])
+    crPixPoint = afwGeom.Point2D(crPix1, crPix2)
 
     fitsHeader = dafBase.PropertyList()
     fitsHeader.set("RADESYS", "ICRS")
     fitsHeader.set("EQUINOX", epoch)
     fitsHeader.set("CRVAL1", obs_metadata.pointingRA)
     fitsHeader.set("CRVAL2", obs_metadata.pointingDec)
-    fitsHeader.set("CRPIX1", crPix1[0]+1) # the +1 is because LSST uses 0-indexed images
-    fitsHeader.set("CRPIX2", crPix2[0]+1) # FITS files use 1-indexed images
+    fitsHeader.set("CRPIX1", crPix1+1) # the +1 is because LSST uses 0-indexed images
+    fitsHeader.set("CRPIX2", crPix2+1) # FITS files use 1-indexed images
     fitsHeader.set("CTYPE1", "RA---TAN")
     fitsHeader.set("CTYPE2", "DEC--TAN")
     fitsHeader.setDouble("CD1_1", coeffs[0])

--- a/python/lsst/sims/GalSimInterface/wcsUtils/WcsUtils.py
+++ b/python/lsst/sims/GalSimInterface/wcsUtils/WcsUtils.py
@@ -76,10 +76,9 @@ def tanWcsFromDetector(afwDetector, afwCamera, obs_metadata, epoch):
 
     dx = 0.5*(xTanPixMax-xTanPixMin)
     dy = 0.5*(yTanPixMax-yTanPixMin)
-    dxPix = xTanPixMax-xTanPixMin
-    dyPix = yTanPixMax-yTanPixMin
+
     for xx in numpy.arange(xTanPixMin, xTanPixMax+0.5*dx, dx):
-        for yy in numpy.arange(yTanPixMin, yTanPixMax+0.5*dyPix, dy):
+        for yy in numpy.arange(yTanPixMin, yTanPixMax+0.5*dy, dy):
             xPixList.append(xx)
             yPixList.append(yy)
             nameList.append(afwDetector.getName())

--- a/tests/testGalSimInterface.py
+++ b/tests/testGalSimInterface.py
@@ -7,10 +7,9 @@ import galsim
 from collections import OrderedDict
 import lsst.utils
 import lsst.utils.tests as utilsTests
-from lsst.sims.utils import arcsecFromRadians, radiansFromArcsec
+from lsst.sims.utils import radiansFromArcsec
 from lsst.sims.photUtils import Bandpass, calcSkyCountsPerPixelForM5, LSSTdefaults, PhotometricParameters
 from lsst.sims.coordUtils import pixelCoordsFromPupilCoords
-from lsst.sims.catalogs.measures.instance import InstanceCatalog
 from lsst.sims.catalogs.generation.utils import makePhoSimTestDB
 from lsst.sims.utils import ObservationMetaData
 from lsst.sims.GalSimInterface import GalSimGalaxies, GalSimStars, GalSimAgn, \
@@ -18,6 +17,7 @@ from lsst.sims.GalSimInterface import GalSimGalaxies, GalSimStars, GalSimAgn, \
 from lsst.sims.catUtils.utils import calcADUwrapper, testGalaxyBulgeDBObj, testGalaxyDiskDBObj, \
                                      testGalaxyAgnDBObj, testStarsDBObj
 import lsst.afw.image as afwImage
+
 
 class testGalaxyCatalog(GalSimGalaxies):
     """
@@ -60,6 +60,7 @@ class testStarCatalog(GalSimStars):
 
     PSF = SNRdocumentPSF()
 
+
 class testAgnCatalog(GalSimAgn):
     """
     Wraps the GalSimAgn class.  Adds columns to the output
@@ -80,11 +81,13 @@ class testAgnCatalog(GalSimAgn):
 
     PSF = SNRdocumentPSF()
 
+
 class psfCatalog(testGalaxyCatalog):
     """
     Adds a PSF to testGalaxyCatalog
     """
     PSF = SNRdocumentPSF()
+
 
 class backgroundCatalog(testGalaxyCatalog):
     """
@@ -92,6 +95,7 @@ class backgroundCatalog(testGalaxyCatalog):
     """
     PSF = SNRdocumentPSF()
     noise_and_background = ExampleCCDNoise(addNoise=False, seed=42)
+
 
 class noisyCatalog(testGalaxyCatalog):
     """
@@ -107,17 +111,18 @@ class testFakeBandpassCatalog(testStarCatalog):
     """
     bandpassNames = ['x', 'y', 'z']
 
-    bandpassDir = os.path.join(lsst.utils.getPackageDir('sims_catUtils'),'tests','testThroughputs')
+    bandpassDir = os.path.join(lsst.utils.getPackageDir('sims_catUtils'), 'tests', 'testThroughputs')
     bandpassRoot = 'fakeFilter_'
     componentList = ['fakeM1.dat', 'fakeM2.dat']
     atmoTransmissionName = 'fakeAtmo.dat'
     skySEDname = 'fakeSky.dat'
 
+
 class testFakeSedCatalog(testFakeBandpassCatalog):
     """
     tests the GalSim interface on fake seds and bandpasses
     """
-    sedDir = os.path.join(lsst.utils.getPackageDir('sims_catUtils'),'tests','testSeds')
+    sedDir = os.path.join(lsst.utils.getPackageDir('sims_catUtils'), 'tests', 'testSeds')
 
     def get_sedFilepath(self):
         """
@@ -125,9 +130,9 @@ class testFakeSedCatalog(testFakeBandpassCatalog):
         in testSeds/
         """
 
-        nameMap = {'km20_5750.fits_g40_5790':'fakeSed1.dat',
-                   'm2.0Full.dat':'fakeSed2.dat',
-                   'bergeron_6500_85.dat_6700':'fakeSed3.dat'}
+        nameMap = {'km20_5750.fits_g40_5790': 'fakeSed1.dat',
+                   'm2.0Full.dat': 'fakeSed2.dat',
+                   'bergeron_6500_85.dat_6700': 'fakeSed3.dat'}
 
         rawNames = self.column_by_name('sedFilename')
         return numpy.array([nameMap[nn] for nn in rawNames])
@@ -156,8 +161,6 @@ class GalSimInterfaceTest(unittest.TestCase):
 
         cls.driver = 'sqlite'
 
-
-
     @classmethod
     def tearDownClass(cls):
         if os.path.exists(cls.dbName):
@@ -170,10 +173,9 @@ class GalSimInterfaceTest(unittest.TestCase):
         del cls.m5
         del cls.seeing
 
-
     def getFilesAndBandpasses(self, catalog, nameRoot=None,
-                                bandpassDir=os.path.join(lsst.utils.getPackageDir('throughputs'),'baseline'),
-                                bandpassRoot='total_',):
+                              bandpassDir=os.path.join(lsst.utils.getPackageDir('throughputs'), 'baseline'),
+                              bandpassRoot='total_',):
 
         """
         Take a GalSimCatalog.  Return a list of fits files and and OrderedDict of bandpasses associated
@@ -193,16 +195,16 @@ class GalSimInterfaceTest(unittest.TestCase):
         filters in this catalog.
         """
 
-        #write the fits files
+        # write the fits files
         catalog.write_images(nameRoot=nameRoot)
 
-        #a list of bandpasses over which we are integraging
+        # a list of bandpasses over which we are integraging
         listOfFilters = []
         listOfFiles = []
 
-        #read in the names of all of the written fits files directly from the
-        #InstanceCatalog's GalSimInterpreter
-        #Use AFW to read in the FITS files and calculate the ADU
+        # read in the names of all of the written fits files directly from the
+        # InstanceCatalog's GalSimInterpreter
+        # Use AFW to read in the FITS files and calculate the ADU
         for name in catalog.galSimInterpreter.detectorImages:
             if nameRoot is not None:
                 name = nameRoot+'_'+name
@@ -214,16 +216,15 @@ class GalSimInterfaceTest(unittest.TestCase):
 
         bandpassDict = OrderedDict()
         for filterName in listOfFilters:
-            bandpassName=os.path.join(bandpassDir, bandpassRoot + filterName + '.dat')
+            bandpassName = os.path.join(bandpassDir, bandpassRoot + filterName + '.dat')
             bandpass = Bandpass()
             bandpass.readThroughput(bandpassName)
             bandpassDict[filterName] = bandpass
 
         return listOfFiles, bandpassDict
 
-
     def catalogTester(self, catName=None, catalog=None, nameRoot=None,
-                      bandpassDir=os.path.join(lsst.utils.getPackageDir('throughputs'),'baseline'),
+                      bandpassDir=os.path.join(lsst.utils.getPackageDir('throughputs'), 'baseline'),
                       bandpassRoot='total_',
                       sedDir=lsst.utils.getPackageDir('sims_sed_library')):
         """
@@ -247,22 +248,22 @@ class GalSimInterfaceTest(unittest.TestCase):
             os.path.join(bandpassDir, bandpassRoot + bandpassName + '.dat')
         """
 
-        #a dictionary of ADU for each FITS file as calculated by GalSim
-        #(indexed on the name of the FITS file)
+        # a dictionary of ADU for each FITS file as calculated by GalSim
+        # (indexed on the name of the FITS file)
         galsimCounts = {}
         galsimPixels = {}
 
-        #a dictionary of ADU for each FITS file as calculated by sims_photUtils
-        #(indexed on the name of the FITS file)
+        # a dictionary of ADU for each FITS file as calculated by sims_photUtils
+        # (indexed on the name of the FITS file)
         controlCounts = {}
 
         listOfFiles, bandpassDict = self.getFilesAndBandpasses(catalog, nameRoot=nameRoot,
-                                                                 bandpassDir=bandpassDir,
-                                                                 bandpassRoot=bandpassRoot)
+                                                               bandpassDir=bandpassDir,
+                                                               bandpassRoot=bandpassRoot)
 
-        #read in the names of all of the written fits files directly from the
-        #InstanceCatalog's GalSimInterpreter
-        #Use AFW to read in the FITS files and calculate the ADU
+        # read in the names of all of the written fits files directly from the
+        # InstanceCatalog's GalSimInterpreter
+        # Use AFW to read in the FITS files and calculate the ADU
         for name in listOfFiles:
             im = afwImage.ImageF(name)
             imArr = im.getArray()
@@ -272,11 +273,13 @@ class GalSimInterfaceTest(unittest.TestCase):
             os.unlink(name)
 
         if catalog.noise_and_background is not None and catalog.noise_and_background.addBackground:
-            #calculate the expected skyCounts in each filter
+            # calculate the expected skyCounts in each filter
             backgroundCounts = {}
             for filterName in bandpassDict.keys():
-                cts = calcSkyCountsPerPixelForM5(catalog.obs_metadata.m5[filterName], bandpassDict[filterName],
-                                             catalog.photParams, FWHMeff=catalog.obs_metadata.seeing[filterName])
+                cts = calcSkyCountsPerPixelForM5(catalog.obs_metadata.m5[filterName],
+                                                 bandpassDict[filterName],
+                                                 catalog.photParams,
+                                                 FWHMeff=catalog.obs_metadata.seeing[filterName])
 
                 backgroundCounts[filterName] = cts
 
@@ -284,8 +287,8 @@ class GalSimInterfaceTest(unittest.TestCase):
                 filterName = name[-6]
                 controlCounts[name] += backgroundCounts[filterName] * galsimPixels[name]
 
-        #Read in the InstanceCatalog.  For each object in the catalog, use sims_photUtils
-        #to calculate the ADU.  Keep track of how many ADU should be in each FITS file.
+        # Read in the InstanceCatalog.  For each object in the catalog, use sims_photUtils
+        # to calculate the ADU.  Keep track of how many ADU should be in each FITS file.
         with open(catName, 'r') as testFile:
             lines = testFile.readlines()
             for line in lines:
@@ -303,30 +306,33 @@ class GalSimInterfaceTest(unittest.TestCase):
 
                     for name in listOfFileNames:
 
-                        #guard against objects being written on one
-                        #chip more than once
+                        # guard against objects being written on one
+                        # chip more than once
                         msg = '%s was written on %s more than once' % (sedName, name)
                         self.assertNotIn(name, alreadyWritten, msg=msg)
                         alreadyWritten.append(name)
 
-                        #loop over all of the detectors on which an object fell
-                        #(this is not a terribly great idea, since our conservative implementation
-                        #of GalSimInterpreter._doesObjectImpingeOnDetector means that some detectors
-                        #will be listed here even though the object does not illumine them)
+                        # loop over all of the detectors on which an object fell
+                        # (this is not a terribly great idea, since our conservative implementation
+                        # of GalSimInterpreter._doesObjectImpingeOnDetector means that some detectors
+                        # will be listed here even though the object does not illumine them)
                         for filterName in bandpassDict.keys():
-                            chipName = name.replace(':','_')
-                            chipName = chipName.replace(' ','_')
-                            chipName = chipName.replace(',','_')
+                            chipName = name.replace(':', '_')
+                            chipName = chipName.replace(' ', '_')
+                            chipName = chipName.replace(',', '_')
                             chipName = chipName.strip()
 
                             fullName = nameRoot+'_'+chipName+'_'+filterName+'.fits'
 
                             fullSedName = os.path.join(sedDir, sedName)
 
-                            controlCounts[fullName] += calcADUwrapper(sedName=fullSedName, bandpass=bandpassDict[filterName],
-                                                                        redshift=redshift, magNorm=magNorm,
-                                                                        internalAv=internalAv, internalRv=internalRv,
-                                                                        galacticAv=galacticAv, galacticRv=galacticRv)
+                            controlCounts[fullName] += calcADUwrapper(sedName=fullSedName,
+                                                                      bandpass=bandpassDict[filterName],
+                                                                      redshift=redshift, magNorm=magNorm,
+                                                                      internalAv=internalAv,
+                                                                      internalRv=internalRv,
+                                                                      galacticAv=galacticAv,
+                                                                      galacticRv=galacticRv)
 
             drawnDetectors = 0
             unDrawnDetectors = 0
@@ -334,24 +340,27 @@ class GalSimInterfaceTest(unittest.TestCase):
                 if controlCounts[ff] > 1000.0 and galsimCounts[ff] > 0.001:
                     countSigma = numpy.sqrt(controlCounts[ff]/catalog.photParams.gain)
 
-                    #because, for really dim images, there could be enough
-                    #statistical imprecision in the GalSim drawing routine
-                    #to violate the condition below
+                    # because, for really dim images, there could be enough
+                    # statistical imprecision in the GalSim drawing routine
+                    # to violate the condition below
                     drawnDetectors += 1
                     msg = 'controlCounts %e galsimCounts %e sigma %e; delta/sigma %e; %s ' % \
-                    (controlCounts[ff], galsimCounts[ff],countSigma,(controlCounts[ff]-galsimCounts[ff])/countSigma,nameRoot)
-                    if catalog.noise_and_background is not None and catalog.noise_and_background.addBackground:
-                        msg += 'background per pixel %e pixels %e %s' % (backgroundCounts[ff[-6]], galsimPixels[ff],ff)
+                          (controlCounts[ff], galsimCounts[ff], countSigma,
+                           (controlCounts[ff]-galsimCounts[ff])/countSigma, nameRoot)
+
+                    if catalog.noise_and_background is not None \
+                    and catalog.noise_and_background.addBackground:
+                        msg += 'background per pixel %e pixels %e %s' % \
+                               (backgroundCounts[ff[-6]], galsimPixels[ff], ff)
 
                     self.assertLess(numpy.abs(controlCounts[ff] - galsimCounts[ff]), 4.0*countSigma,
                                     msg=msg)
                 elif galsimCounts[ff] > 0.001:
                     unDrawnDetectors += 1
 
-            #to make sure we did not neglect more than one detector
+            # to make sure we did not neglect more than one detector
             self.assertLess(unDrawnDetectors, 2)
             self.assertGreater(drawnDetectors, 0)
-
 
     def compareCatalogs(self, cleanCatalog, noisyCatalog, gain, readnoise):
         """
@@ -370,11 +379,13 @@ class GalSimInterfaceTest(unittest.TestCase):
         cleanFileList, cleanBandpassDict = self.getFilesAndBandpasses(cleanCatalog, nameRoot='clean')
         noisyFileList, noisyBandpassDict = self.getFilesAndBandpasses(noisyCatalog, nameRoot='unclean')
 
-        #calculate the expected skyCounts in each filter
+        # calculate the expected skyCounts in each filter
         backgroundCounts = {}
         for filterName in noisyBandpassDict.keys():
-            cts = calcSkyCountsPerPixelForM5(noisyCatalog.obs_metadata.m5[filterName], noisyBandpassDict[filterName],
-                                         noisyCatalog.photParams, FWHMeff=noisyCatalog.obs_metadata.seeing[filterName])
+            cts = calcSkyCountsPerPixelForM5(noisyCatalog.obs_metadata.m5[filterName],
+                                             noisyBandpassDict[filterName],
+                                             noisyCatalog.photParams,
+                                             FWHMeff=noisyCatalog.obs_metadata.seeing[filterName])
 
             backgroundCounts[filterName] = cts
 
@@ -398,13 +409,13 @@ class GalSimInterfaceTest(unittest.TestCase):
             self.assertEqual(cleanIm.shape[1], noisyIm.shape[1], msg='images not same shape')
 
             var = cleanIm/gain + readnoise/(gain*gain)
-            totalVar = (numpy.power(noisyIm-cleanIm,2)/var).sum()
+            totalVar = (numpy.power(noisyIm-cleanIm, 2)/var).sum()
             totalMean = cleanIm.sum()
             ct = float(cleanIm.shape[0]*cleanIm.shape[1])
             totalVar = totalVar/ct
             totalMean = totalMean/ct
 
-            if totalMean>=100.0:
+            if totalMean >= 100.0:
                 countedImages += 1
                 self.assertLess(numpy.abs(totalVar-1.0), 0.05)
 
@@ -412,7 +423,6 @@ class GalSimInterfaceTest(unittest.TestCase):
             os.unlink(cleanName)
 
         self.assertGreater(countedImages, 0)
-
 
     def testGalaxyBulges(self):
         """
@@ -426,7 +436,6 @@ class GalSimInterfaceTest(unittest.TestCase):
         if os.path.exists(catName):
             os.unlink(catName)
 
-
     def testGalaxyDisks(self):
         """
         Test that GalSimInterpreter puts the right number of counts on images of galaxy disks
@@ -438,7 +447,6 @@ class GalSimInterfaceTest(unittest.TestCase):
         self.catalogTester(catName=catName, catalog=cat, nameRoot='disk')
         if os.path.exists(catName):
             os.unlink(catName)
-
 
     def testStars(self):
         """
@@ -452,7 +460,6 @@ class GalSimInterfaceTest(unittest.TestCase):
         if os.path.exists(catName):
             os.unlink(catName)
 
-
     def testFakeBandpasses(self):
         """
         Test GalSim catalog with alternate bandpasses
@@ -461,19 +468,18 @@ class GalSimInterfaceTest(unittest.TestCase):
         m5 = [22.0, 23.0, 25.0]
         seeing = [0.6, 0.5, 0.7]
         bandpassNames = ['x', 'y', 'z']
-        obs_metadata = ObservationMetaData(
-                       pointingRA=self.obs_metadata.pointingRA,
-                       pointingDec=self.obs_metadata.pointingDec,
-                       rotSkyPos=self.obs_metadata.rotSkyPos,
-                       mjd=self.obs_metadata.mjd,
-                       bandpassName=bandpassNames,
-                       m5=m5,
-                       seeing=seeing)
+        obs_metadata = ObservationMetaData(pointingRA=self.obs_metadata.pointingRA,
+                                           pointingDec=self.obs_metadata.pointingDec,
+                                           rotSkyPos=self.obs_metadata.rotSkyPos,
+                                           mjd=self.obs_metadata.mjd,
+                                           bandpassName=bandpassNames,
+                                           m5=m5,
+                                           seeing=seeing)
 
         stars = testStarsDBObj(driver=self.driver, database=self.dbName)
         cat = testFakeBandpassCatalog(stars, obs_metadata=obs_metadata)
         cat.write_catalog(catName)
-        bandpassDir = os.path.join(lsst.utils.getPackageDir('sims_catUtils'),'tests','testThroughputs')
+        bandpassDir = os.path.join(lsst.utils.getPackageDir('sims_catUtils'), 'tests', 'testThroughputs')
         self.catalogTester(catName=catName, catalog=cat, nameRoot='fakeBandpass',
                            bandpassDir=bandpassDir, bandpassRoot='fakeTotal_')
 
@@ -488,14 +494,13 @@ class GalSimInterfaceTest(unittest.TestCase):
         m5 = [22.0, 23.0, 25.0]
         seeing = [0.6, 0.5, 0.7]
         bandpassNames = ['x', 'y', 'z']
-        obs_metadata = ObservationMetaData(
-                       pointingRA=self.obs_metadata.pointingRA,
-                       pointingDec=self.obs_metadata.pointingDec,
-                       rotSkyPos=self.obs_metadata.rotSkyPos,
-                       mjd=self.obs_metadata.mjd,
-                       bandpassName=bandpassNames,
-                       m5=m5,
-                       seeing=seeing)
+        obs_metadata = ObservationMetaData(pointingRA=self.obs_metadata.pointingRA,
+                                           pointingDec=self.obs_metadata.pointingDec,
+                                           rotSkyPos=self.obs_metadata.rotSkyPos,
+                                           mjd=self.obs_metadata.mjd,
+                                           bandpassName=bandpassNames,
+                                           m5=m5,
+                                           seeing=seeing)
 
         stars = testStarsDBObj(driver=self.driver, database=self.dbName)
         cat = testFakeSedCatalog(stars, obs_metadata=obs_metadata)
@@ -509,8 +514,6 @@ class GalSimInterfaceTest(unittest.TestCase):
         if os.path.exists(catName):
             os.unlink(catName)
 
-
-
     def testAgns(self):
         """
         Test that GalSimInterpreter puts the right number of counts on images of AGN
@@ -522,7 +525,6 @@ class GalSimInterfaceTest(unittest.TestCase):
         self.catalogTester(catName=catName, catalog=cat, nameRoot='agn')
         if os.path.exists(catName):
             os.unlink(catName)
-
 
     def testPSFimages(self):
         """
@@ -537,7 +539,6 @@ class GalSimInterfaceTest(unittest.TestCase):
         if os.path.exists(catName):
             os.unlink(catName)
 
-
     def testBackground(self):
         """
         Test that GalSimInterpreter puts the right number of counts on images of Galaxy bulges with
@@ -550,7 +551,6 @@ class GalSimInterfaceTest(unittest.TestCase):
         self.catalogTester(catName=catName, catalog=cat, nameRoot='background')
         if os.path.exists(catName):
             os.unlink(catName)
-
 
     def testNoisyCatalog(self):
         """
@@ -569,13 +569,13 @@ class GalSimInterfaceTest(unittest.TestCase):
         noisyCat.write_catalog(noisyCatName)
         cleanCat.write_catalog(cleanCatName)
 
-        self.compareCatalogs(cleanCat, noisyCat, PhotometricParameters().gain, PhotometricParameters().readnoise)
+        self.compareCatalogs(cleanCat, noisyCat, PhotometricParameters().gain,
+                             PhotometricParameters().readnoise)
 
         if os.path.exists(noisyCatName):
             os.unlink(noisyCatName)
         if os.path.exists(cleanCatName):
             os.unlink(cleanCatName)
-
 
     def testNoise(self):
         """
@@ -587,14 +587,15 @@ class GalSimInterfaceTest(unittest.TestCase):
         lsstDefaults = LSSTdefaults()
         gain = 2.5
         readnoise = 6.0
-        photParams=PhotometricParameters(gain=gain, readnoise=readnoise)
-        img = galsim.Image(100,100)
+        photParams = PhotometricParameters(gain=gain, readnoise=readnoise)
+        img = galsim.Image(100, 100)
         noise = ExampleCCDNoise(seed=42)
         m5 = 24.5
         bandpass = Bandpass()
-        bandpass.readThroughput(os.path.join(lsst.utils.getPackageDir('throughputs'),'baseline','total_r.dat'))
+        bandpass.readThroughput(os.path.join(lsst.utils.getPackageDir('throughputs'),
+                                             'baseline', 'total_r.dat'))
         background = calcSkyCountsPerPixelForM5(m5, bandpass, FWHMeff=lsstDefaults.FWHMeff('r'),
-                                            photParams=photParams)
+                                                photParams=photParams)
 
         noisyImage = noise.addNoiseAndBackground(img, bandpass, m5=m5,
                                                  FWHMeff=lsstDefaults.FWHMeff('r'),
@@ -602,14 +603,14 @@ class GalSimInterfaceTest(unittest.TestCase):
 
         mean = 0.0
         var = 0.0
-        for ix in range(1,101):
-            for iy in range(1,101):
+        for ix in range(1, 101):
+            for iy in range(1, 101):
                 mean += noisyImage(ix, iy)
 
         mean = mean/10000.0
 
-        for ix in range(1,101):
-            for iy in range(1,101):
+        for ix in range(1, 101):
+            for iy in range(1, 101):
                 var += (noisyImage(ix, iy) - mean)*(noisyImage(ix, iy) - mean)
 
         var = var/9999.0
@@ -622,7 +623,6 @@ class GalSimInterfaceTest(unittest.TestCase):
 
         msg = 'var %e varADU %e ; ratio %e ; background %e' % (var, varADU, var/varADU, background)
         self.assertLess(numpy.abs(var/varADU - 1.0), 0.05, msg=msg)
-
 
     def testMultipleImages(self):
         """
@@ -660,10 +660,10 @@ class GalSimInterfaceTest(unittest.TestCase):
         if os.path.exists(dbName):
             os.unlink(dbName)
 
-
     def testCompoundFitsFiles(self):
         """
-        Test that GalSimInterpreter puts the right number of counts on images containgin different types of objects
+        Test that GalSimInterpreter puts the right number of counts on images
+        containing different types of objects
         """
         driver = 'sqlite'
         dbName1 = 'galSimTestCompound1DB.db'
@@ -684,9 +684,9 @@ class GalSimInterfaceTest(unittest.TestCase):
         displacedRA = numpy.array([55.0/3600.0, 60.0/3600.0, 62.0/3600.0])
         displacedDec = numpy.array([-3.0/3600.0, 10.0/3600.0, 10.0/3600.0])
         obs_metadata2 = makePhoSimTestDB(filename=dbName2, size=1,
-                                            displacedRA=displacedRA, displacedDec=displacedDec,
-                                            bandpass=self.bandpassNameList,
-                                            m5=self.m5, seeing=self.seeing)
+                                         displacedRA=displacedRA, displacedDec=displacedDec,
+                                         bandpass=self.bandpassNameList,
+                                         m5=self.m5, seeing=self.seeing)
 
         gals = testGalaxyBulgeDBObj(driver=driver, database=dbName1)
         cat1 = testGalaxyCatalog(gals, obs_metadata=obs_metadata1)
@@ -706,7 +706,6 @@ class GalSimInterfaceTest(unittest.TestCase):
         if os.path.exists(catName):
             os.unlink(catName)
 
-
     def testPlacement(self):
         """
         Test that GalSimInterpreter puts objects on the right detectors.
@@ -724,7 +723,7 @@ class GalSimInterfaceTest(unittest.TestCase):
         (i.e. detectors on which no star actually fell) are effectively zero
         """
 
-        #generate the database
+        # generate the database
         numpy.random.seed(32)
         rng = galsim.UniformDeviate(112)
         catSize = 3
@@ -739,38 +738,30 @@ class GalSimInterfaceTest(unittest.TestCase):
                                         bandpass=self.bandpassNameList,
                                         m5=self.m5, seeing=self.seeing)
 
-        catName = 'testPlacementCat.sav'
         stars = testStarsDBObj(driver=driver, database=dbName)
 
-        #create the catalog
+        # create the catalog
         cat = testStarCatalog(stars, obs_metadata = obs_metadata)
         results = cat.iter_catalog()
         firstLine = True
 
-        #iterate over the catalog, giving every star a chance to
-        #illumine every detector
+        # iterate over the catalog, giving every star a chance to
+        # illumine every detector
         controlImages = {}
         for i, line in enumerate(results):
-            galSimType = line[0]
             xPupil = line[5]
             yPupil = line[6]
 
-
-            majorAxis = line[8]
-            minorAxis = line[9]
-            sindex = line[10]
-            halfLightRadius = line[11]
-            positionAngle = line[12]
             if firstLine:
                 sedList = cat._calculateGalSimSeds()
                 for detector in cat.galSimInterpreter.detectors:
                     for bandpass in cat.galSimInterpreter.bandpassDict:
-                        controlImages['placementControl_' + \
-                                      cat.galSimInterpreter._getFileName(detector=detector, bandpassName=bandpass)] = \
+                        controlImages['placementControl_' +
+                                      cat.galSimInterpreter._getFileName(
+                                      detector=detector, bandpassName=bandpass)] = \
                                       cat.galSimInterpreter.blankImage(detector=detector)
                 firstLine = False
 
-            spectrum = sedList[i]
             for bp in cat.galSimInterpreter.bandpassDict:
                 bandpass = cat.galSimInterpreter.bandpassDict[bp]
                 adu = sedList[i].calcADU(bandpass, cat.photParams)
@@ -791,7 +782,7 @@ class GalSimInterfaceTest(unittest.TestCase):
                                                offset=galsim.PositionD(dx, dy),
                                                rng=rng)
 
-                    controlImages['placementControl_' + \
+                    controlImages['placementControl_' +
                                   cat.galSimInterpreter._getFileName(detector=detector, bandpassName=bp)] += \
                                   localImage
 
@@ -800,16 +791,16 @@ class GalSimInterfaceTest(unittest.TestCase):
         for name in controlImages:
             controlImages[name].write(file_name=name)
 
-        #write the test images using the catalog infrastructure
+        # write the test images using the catalog infrastructure
         testNames = cat.write_images(nameRoot='placementTest')
 
-        #make sure that every test image has a corresponding control image
+        # make sure that every test image has a corresponding control image
         for testName in testNames:
             controlName = testName.replace('Test', 'Control')
             msg = '%s has no counterpart ' % testName
             self.assertIn(controlName, controlImages, msg=msg)
 
-        #make sure that the test and control images agree to some tolerance
+        # make sure that the test and control images agree to some tolerance
         ignored = 0
         zeroFlux = 0
         valid = 0
@@ -821,19 +812,19 @@ class GalSimInterfaceTest(unittest.TestCase):
             if testName in testNames:
                 testImage = afwImage.ImageF(testName)
                 testFlux = testImage.getArray().sum()
-                if controlFlux>1000.0:
+                if controlFlux > 1000.0:
                     countSigma = numpy.sqrt(controlFlux/cat.photParams.gain)
                     msg = '%s: controlFlux = %e, testFlux = %e, sigma %e' \
-                    % (controlName, controlFlux, testFlux, countSigma)
+                          % (controlName, controlFlux, testFlux, countSigma)
 
-                    #the randomness of photon shooting means that faint images won't agree
+                    # the randomness of photon shooting means that faint images won't agree
                     self.assertLess(numpy.abs(controlFlux-testFlux), 4.0*countSigma, msg=msg)
                     valid += 1
                 else:
                     ignored += 1
             else:
-                #make sure that controlImages that have no corresponding test image really do
-                #have zero flux (because no star fell on them)
+                # make sure that controlImages that have no corresponding test image really do
+                # have zero flux (because no star fell on them)
                 zeroFlux += 1
                 msg = '%s has flux %e but was not written by catalog' % (controlName, controlFlux)
                 self.assertLess(controlFlux, 1.0, msg=msg)
@@ -853,28 +844,27 @@ class GalSimInterfaceTest(unittest.TestCase):
         if os.path.exists(dbName):
             os.unlink(dbName)
 
-
     def testPSF(self):
         """
         This method will test that SNRdocumentPSF returns a PSF
         with the correct Full Width at Half Max
         """
 
-        fwhm = 0.4 #in arc-seconds; make sure that it divides evenly by scale, so that rounding
-                   #half integer numbers of pixels does not affect the unit test
+        fwhm = 0.4  # in arc-seconds; make sure that it divides evenly by scale, so that rounding
+                    # half integer numbers of pixels does not affect the unit test
 
-        scale = 0.1 #arc-seconds per pixel
+        scale = 0.1  # arc-seconds per pixel
 
         psf = SNRdocumentPSF(fwhm=fwhm)
         image = psf._cached_psf.drawImage(scale=scale)
         xCenter = (image.getXMax() + image.getXMin())/2
         yCenter = (image.getYMax() + image.getYMin())/2
 
-        maxValue = image(xCenter, yCenter) #because the default is to center GSObjects
-        halfDex = int(numpy.round(0.5*fwhm/scale)) #the distance from the center corresponding to FWHM
+        maxValue = image(xCenter, yCenter)  # because the default is to center GSObjects
+        halfDex = int(numpy.round(0.5*fwhm/scale))  # the distance from the center corresponding to FWHM
 
-        #Test that pixel combinations bracketing the expected FWHM value behave
-        #the way we expect them to
+        # Test that pixel combinations bracketing the expected FWHM value behave
+        # the way we expect them to
         midP1 = image(xCenter+halfDex+1, yCenter)
         midM1 = image(xCenter+halfDex-1, yCenter)
         msg = '%e is not > %e ' % (midM1, 0.5*maxValue)
@@ -882,7 +872,6 @@ class GalSimInterfaceTest(unittest.TestCase):
         msg = '%e is not < %e ' % (midP1, 0.5*maxValue)
         self.assertLess(midP1, 0.5*maxValue, msg=msg)
 
-        midValue = image(xCenter-halfDex, yCenter)
         midP1 = image(xCenter-halfDex-1, yCenter)
         midM1 = image(xCenter-halfDex+1, yCenter)
         msg = '%e is not > %e ' % (midM1, 0.5*maxValue)
@@ -911,6 +900,7 @@ def suite():
     suites += unittest.makeSuite(GalSimInterfaceTest)
 
     return unittest.TestSuite(suites)
+
 
 def run(shouldExit = False):
     utilsTests.run(suite(), shouldExit)

--- a/tests/testGalSimInterface.py
+++ b/tests/testGalSimInterface.py
@@ -1,7 +1,7 @@
 from __future__ import with_statement
 import os
 import copy
-import numpy
+import numpy as np
 import unittest
 import galsim
 from collections import OrderedDict
@@ -135,7 +135,7 @@ class testFakeSedCatalog(testFakeBandpassCatalog):
                    'bergeron_6500_85.dat_6700': 'fakeSed3.dat'}
 
         rawNames = self.column_by_name('sedFilename')
-        return numpy.array([nameMap[nn] for nn in rawNames])
+        return np.array([nameMap[nn] for nn in rawNames])
 
 
 class GalSimInterfaceTest(unittest.TestCase):
@@ -146,8 +146,8 @@ class GalSimInterfaceTest(unittest.TestCase):
         if os.path.exists(cls.dbName):
             os.unlink(cls.dbName)
 
-        displacedRA = numpy.array([72.0/3600.0])
-        displacedDec = numpy.array([0.0])
+        displacedRA = np.array([72.0/3600.0])
+        displacedDec = np.array([0.0])
         defaults = LSSTdefaults()
         cls.bandpassNameList = ['u', 'g', 'r', 'i', 'z', 'y']
         cls.m5 = defaults._m5.values()
@@ -338,7 +338,7 @@ class GalSimInterfaceTest(unittest.TestCase):
             unDrawnDetectors = 0
             for ff in controlCounts:
                 if controlCounts[ff] > 1000.0 and galsimCounts[ff] > 0.001:
-                    countSigma = numpy.sqrt(controlCounts[ff]/catalog.photParams.gain)
+                    countSigma = np.sqrt(controlCounts[ff]/catalog.photParams.gain)
 
                     # because, for really dim images, there could be enough
                     # statistical imprecision in the GalSim drawing routine
@@ -353,7 +353,7 @@ class GalSimInterfaceTest(unittest.TestCase):
                         msg += 'background per pixel %e pixels %e %s' % \
                                (backgroundCounts[ff[-6]], galsimPixels[ff], ff)
 
-                    self.assertLess(numpy.abs(controlCounts[ff] - galsimCounts[ff]), 4.0*countSigma,
+                    self.assertLess(np.abs(controlCounts[ff] - galsimCounts[ff]), 4.0*countSigma,
                                     msg=msg)
                 elif galsimCounts[ff] > 0.001:
                     unDrawnDetectors += 1
@@ -409,7 +409,7 @@ class GalSimInterfaceTest(unittest.TestCase):
             self.assertEqual(cleanIm.shape[1], noisyIm.shape[1], msg='images not same shape')
 
             var = cleanIm/gain + readnoise/(gain*gain)
-            totalVar = (numpy.power(noisyIm-cleanIm, 2)/var).sum()
+            totalVar = (np.power(noisyIm-cleanIm, 2)/var).sum()
             totalMean = cleanIm.sum()
             ct = float(cleanIm.shape[0]*cleanIm.shape[1])
             totalVar = totalVar/ct
@@ -417,7 +417,7 @@ class GalSimInterfaceTest(unittest.TestCase):
 
             if totalMean >= 100.0:
                 countedImages += 1
-                self.assertLess(numpy.abs(totalVar-1.0), 0.05)
+                self.assertLess(np.abs(totalVar-1.0), 0.05)
 
             os.unlink(noisyName)
             os.unlink(cleanName)
@@ -619,10 +619,10 @@ class GalSimInterfaceTest(unittest.TestCase):
         varADU = varElectrons/(gain*gain)
 
         msg = 'background %e mean %e ' % (background, mean)
-        self.assertLess(numpy.abs(background/mean - 1.0), 0.05, msg=msg)
+        self.assertLess(np.abs(background/mean - 1.0), 0.05, msg=msg)
 
         msg = 'var %e varADU %e ; ratio %e ; background %e' % (var, varADU, var/varADU, background)
-        self.assertLess(numpy.abs(var/varADU - 1.0), 0.05, msg=msg)
+        self.assertLess(np.abs(var/varADU - 1.0), 0.05, msg=msg)
 
     def testMultipleImages(self):
         """
@@ -634,8 +634,8 @@ class GalSimInterfaceTest(unittest.TestCase):
         if os.path.exists(dbName):
             os.unlink(dbName)
 
-        displacedRA = numpy.array([72.0/3600.0, 55.0/3600.0, 75.0/3600.0])
-        displacedDec = numpy.array([0.0, 15.0/3600.0, -15.0/3600.0])
+        displacedRA = np.array([72.0/3600.0, 55.0/3600.0, 75.0/3600.0])
+        displacedDec = np.array([0.0, 15.0/3600.0, -15.0/3600.0])
         obs_metadata = makePhoSimTestDB(filename=dbName, size=1,
                                         displacedRA=displacedRA, displacedDec=displacedDec,
                                         bandpass=self.bandpassNameList,
@@ -670,8 +670,8 @@ class GalSimInterfaceTest(unittest.TestCase):
         if os.path.exists(dbName1):
             os.unlink(dbName1)
 
-        displacedRA = numpy.array([72.0/3600.0, 55.0/3600.0, 75.0/3600.0])
-        displacedDec = numpy.array([0.0, 15.0/3600.0, -15.0/3600.0])
+        displacedRA = np.array([72.0/3600.0, 55.0/3600.0, 75.0/3600.0])
+        displacedDec = np.array([0.0, 15.0/3600.0, -15.0/3600.0])
         obs_metadata1 = makePhoSimTestDB(filename=dbName1, size=1,
                                          displacedRA=displacedRA, displacedDec=displacedDec,
                                          bandpass=self.bandpassNameList,
@@ -681,8 +681,8 @@ class GalSimInterfaceTest(unittest.TestCase):
         if os.path.exists(dbName2):
             os.unlink(dbName2)
 
-        displacedRA = numpy.array([55.0/3600.0, 60.0/3600.0, 62.0/3600.0])
-        displacedDec = numpy.array([-3.0/3600.0, 10.0/3600.0, 10.0/3600.0])
+        displacedRA = np.array([55.0/3600.0, 60.0/3600.0, 62.0/3600.0])
+        displacedDec = np.array([-3.0/3600.0, 10.0/3600.0, 10.0/3600.0])
         obs_metadata2 = makePhoSimTestDB(filename=dbName2, size=1,
                                          displacedRA=displacedRA, displacedDec=displacedDec,
                                          bandpass=self.bandpassNameList,
@@ -724,7 +724,7 @@ class GalSimInterfaceTest(unittest.TestCase):
         """
 
         # generate the database
-        numpy.random.seed(32)
+        np.random.seed(32)
         rng = galsim.UniformDeviate(112)
         catSize = 3
         dbName = 'galSimPlacementTestDB.db'
@@ -732,8 +732,8 @@ class GalSimInterfaceTest(unittest.TestCase):
         if os.path.exists(dbName):
             os.unlink(dbName)
 
-        displacedRA = (-40.0 + numpy.random.sample(catSize)*(120.0))/3600.0
-        displacedDec = (-20.0 + numpy.random.sample(catSize)*(80.0))/3600.0
+        displacedRA = (-40.0 + np.random.sample(catSize)*(120.0))/3600.0
+        displacedDec = (-20.0 + np.random.sample(catSize)*(80.0))/3600.0
         obs_metadata = makePhoSimTestDB(filename=dbName, displacedRA=displacedRA, displacedDec=displacedDec,
                                         bandpass=self.bandpassNameList,
                                         m5=self.m5, seeing=self.seeing)
@@ -813,12 +813,12 @@ class GalSimInterfaceTest(unittest.TestCase):
                 testImage = afwImage.ImageF(testName)
                 testFlux = testImage.getArray().sum()
                 if controlFlux > 1000.0:
-                    countSigma = numpy.sqrt(controlFlux/cat.photParams.gain)
+                    countSigma = np.sqrt(controlFlux/cat.photParams.gain)
                     msg = '%s: controlFlux = %e, testFlux = %e, sigma %e' \
                           % (controlName, controlFlux, testFlux, countSigma)
 
                     # the randomness of photon shooting means that faint images won't agree
-                    self.assertLess(numpy.abs(controlFlux-testFlux), 4.0*countSigma, msg=msg)
+                    self.assertLess(np.abs(controlFlux-testFlux), 4.0*countSigma, msg=msg)
                     valid += 1
                 else:
                     ignored += 1
@@ -861,7 +861,7 @@ class GalSimInterfaceTest(unittest.TestCase):
         yCenter = (image.getYMax() + image.getYMin())/2
 
         maxValue = image(xCenter, yCenter)  # because the default is to center GSObjects
-        halfDex = int(numpy.round(0.5*fwhm/scale))  # the distance from the center corresponding to FWHM
+        halfDex = int(np.round(0.5*fwhm/scale))  # the distance from the center corresponding to FWHM
 
         # Test that pixel combinations bracketing the expected FWHM value behave
         # the way we expect them to

--- a/tests/testGalSimInterface.py
+++ b/tests/testGalSimInterface.py
@@ -777,13 +777,13 @@ class GalSimInterfaceTest(unittest.TestCase):
                 for detector in cat.galSimInterpreter.detectors:
                     centeredObj = cat.galSimInterpreter.PSF.applyPSF(xPupil=xPupil, yPupil=yPupil)
 
-                    xPix, yPix = pixelCoordsFromPupilCoords(numpy.array([radiansFromArcsec(xPupil)]),
-                                                            numpy.array([radiansFromArcsec(yPupil)]),
-                                                            chipNames = [detector.name],
+                    xPix, yPix = pixelCoordsFromPupilCoords(radiansFromArcsec(xPupil),
+                                                            radiansFromArcsec(yPupil),
+                                                            chipName = detector.name,
                                                             camera = detector.afwCamera)
 
-                    dx = xPix[0] - detector.xCenterPix
-                    dy = yPix[0] - detector.yCenterPix
+                    dx = xPix - detector.xCenterPix
+                    dy = yPix - detector.yCenterPix
                     obj = centeredObj.withFlux(adu*detector.photParams.gain)
                     localImage = cat.galSimInterpreter.blankImage(detector=detector)
                     localImage = obj.drawImage(wcs=detector.wcs, method='phot',

--- a/tests/testPlacement.py
+++ b/tests/testPlacement.py
@@ -101,7 +101,7 @@ class GalSimPlacementTest(unittest.TestCase):
 
         nameList = [detector.getName()]*len(raList)
         xPixList, yPixList = _pixelCoordsFromRaDec(raList, decList,
-                                                   chipNames=nameList,
+                                                   chipName=nameList,
                                                    camera=camera,
                                                    obs_metadata=obs,
                                                    epoch=epoch)


### PR DESCRIPTION
This pull request incorporates the methods I drew up for the camera team to find the coordinates of the corners of specific chips into sims_coordUtils.  I took the opportunity to clean up a few things about the sims_coordUtils and sims_utils API.  Namely: there were several coordinate transformation methods that could only accept numpy arrays as inputs.  They could not accept single floats.  I fixed those methods so that they can accept either numpy arrays or floats.  I also standardized the names of args in the methods defined in sims_coordUtils/CameraUtils.py.

Like any good pull request, this had implications beyond sims_coordUtils.  There are pull requests in
sims_utils
sims_coordUtils
sims_catUtils
and sims_GalSimInterface
all of which must be built together.