### PR TITLE
Feature/sim 1471/pho sim meta data

### DIFF
--- a/python/lsst/sims/GalSimInterface/galSimDetector.py
+++ b/python/lsst/sims/GalSimInterface/galSimDetector.py
@@ -4,9 +4,9 @@ import numpy as np
 import lsst.afw.geom as afwGeom
 from lsst.afw.cameraGeom import PUPIL, PIXELS, FOCAL_PLANE
 from lsst.sims.utils import arcsecFromRadians
-from lsst.sims.coordUtils import _raDecFromPixelCoords, \
-                                 _pixelCoordsFromRaDec, \
-                                 pixelCoordsFromPupilCoords
+from lsst.sims.coordUtils import (_raDecFromPixelCoords,
+                                  _pixelCoordsFromRaDec,
+                                  pixelCoordsFromPupilCoords)
 from lsst.sims.GalSimInterface.wcsUtils import tanSipWcsFromDetector
 
 __all__ = ["GalSimDetector"]

--- a/python/lsst/sims/GalSimInterface/galSimDetector.py
+++ b/python/lsst/sims/GalSimInterface/galSimDetector.py
@@ -540,8 +540,8 @@ class GalSimDetector(object):
                 if self.obs_metadata.phoSimMetaData is not None:
                     if 'Opsim_obshistid' in self.obs_metadata.phoSimMetaData:
                         self._wcs.fitsHeader.set("OBSID",
-                                                 self.obs_metadata.phoSimMetaData['Opsim_obshistid'][0])
-                        obshistid = self.obs_metadata.phoSimMetaData['Opsim_obshistid'][0]
+                                                 self.obs_metadata.phoSimMetaData['Opsim_obshistid'])
+                        obshistid = self.obs_metadata.phoSimMetaData['Opsim_obshistid']
 
                 bp = self.obs_metadata.bandpass
                 if not isinstance(bp, list) and not isinstance(bp, np.ndarray):

--- a/tests/testAllowedChips.py
+++ b/tests/testAllowedChips.py
@@ -53,7 +53,8 @@ class allowedChipsTest(unittest.TestCase):
     def setUpClass(cls):
         cls.scratchDir = os.path.join(getPackageDir('sims_GalSimInterface'), 'tests', 'scratchSpace')
         cls.obs = ObservationMetaData(pointingRA=122.0, pointingDec=-29.1,
-                                      mjd=57381.2, rotSkyPos=43.2)
+                                      mjd=57381.2, rotSkyPos=43.2,
+                                      bandpassName='r')
 
 
         cls.camera = camTestUtils.CameraWrapper().camera

--- a/tests/testAllowedChips.py
+++ b/tests/testAllowedChips.py
@@ -22,10 +22,9 @@ class allowedChipsFileDBObj(fileDBObject):
     tableid = 'test'
     raColName = 'ra'
     decColName = 'dec'
-    #sedFilename
 
-    columns = [('raJ2000','ra*PI()/180.0', np.float),
-               ('decJ2000','dec*PI()/180.0', np.float),
+    columns = [('raJ2000', 'ra*PI()/180.0', np.float),
+               ('decJ2000', 'dec*PI()/180.0', np.float),
                ('magNorm', 'mag_norm', np.float)]
 
 
@@ -39,7 +38,7 @@ class allowedChipsCatalog(GalSimStars):
 
     default_columns = GalSimStars.default_columns
 
-    default_columns += [('sedFilename', 'sed_flat.txt', (str,12)),
+    default_columns += [('sedFilename', 'sed_flat.txt', (str, 12)),
                         ('properMotionRa', 0.0, np.float),
                         ('properMotionDec', 0.0, np.float),
                         ('radialVelocity', 0.0, np.float),
@@ -56,7 +55,6 @@ class allowedChipsTest(unittest.TestCase):
                                       mjd=57381.2, rotSkyPos=43.2,
                                       bandpassName='r')
 
-
         cls.camera = camTestUtils.CameraWrapper().camera
 
         cls.dbFileName = os.path.join(cls.scratchDir, 'allowed_chips_test_db.txt')
@@ -65,7 +63,7 @@ class allowedChipsTest(unittest.TestCase):
 
         cls.controlSed = Sed()
         cls.controlSed.readSED_flambda(os.path.join(getPackageDir('sims_sed_library'),
-                                               'flatSED','sed_flat.txt.gz'))
+                                                    'flatSED', 'sed_flat.txt.gz'))
         cls.magNorm = 18.1
         imsim = Bandpass()
         imsim.imsimBandpass()
@@ -103,7 +101,6 @@ class allowedChipsTest(unittest.TestCase):
                             mag_norm=[cls.magNorm]*len(dra_list))
 
         cls.db = allowedChipsFileDBObj(cls.dbFileName, runtable='test')
-
 
     @classmethod
     def tearDownClass(cls):
@@ -199,7 +196,6 @@ class allowedChipsTest(unittest.TestCase):
                 msg = '%s exists; it should not' % test_image_name
                 self.assertFalse(os.path.exists(test_image_name), msg=msg)
 
-
         self.assertEqual(test_image_ct, len(allowed_chips))
 
         if os.path.exists(test_cat_name):
@@ -215,7 +211,10 @@ def suite():
 
     return unittest.TestSuite(suites)
 
+
 def run(shouldExit = False):
     utilsTests.run(suite(), shouldExit)
+
+
 if __name__ == "__main__":
     run(True)

--- a/tests/testFitsHeaders.py
+++ b/tests/testFitsHeaders.py
@@ -72,8 +72,9 @@ class FitsHeaderTest(unittest.TestCase):
 
         obs = ObservationMetaData(pointingRA=32.0, pointingDec=22.0,
                                   boundLength=0.1, boundType='circle',
-                                  mjd=58000.0, rotSkyPos=14.0, bandpassName='u',
-                                  phoSimMetaData={'Opsim_obshistid':(112, int)})
+                                  mjd=58000.0, rotSkyPos=14.0, bandpassName='u')
+
+        obs.phoSimMetaData = {'Opsim_obshistid': 112}
 
         dbFileName = os.path.join(outputDir, 'fits_test_db.dat')
         create_text_catalog(obs, dbFileName, np.array([30.0]), np.array([30.0]), [22.0])

--- a/tests/testFitsHeaders.py
+++ b/tests/testFitsHeaders.py
@@ -14,16 +14,16 @@ from lsst.obs.lsstSim import LsstSimMapper
 
 from testUtils import create_text_catalog
 
+
 class fitsHeaderFileDBObj(fileDBObject):
     idColKey = 'test_id'
     objectTypeId = 8123
     tableid = 'test'
     raColName = 'ra'
     decColName = 'dec'
-    #sedFilename
 
-    columns = [('raJ2000','ra*PI()/180.0', np.float),
-               ('decJ2000','dec*PI()/180.0', np.float),
+    columns = [('raJ2000', 'ra*PI()/180.0', np.float),
+               ('decJ2000', 'dec*PI()/180.0', np.float),
                ('magNorm', 'mag_norm', np.float)]
 
 
@@ -37,13 +37,12 @@ class fitsHeaderCatalog(GalSimStars):
 
     default_columns = GalSimStars.default_columns
 
-    default_columns += [('sedFilename', 'sed_flat.txt', (str,12)),
+    default_columns += [('sedFilename', 'sed_flat.txt', (str, 12)),
                         ('properMotionRa', 0.0, np.float),
                         ('properMotionDec', 0.0, np.float),
                         ('radialVelocity', 0.0, np.float),
                         ('parallax', 0.0, np.float)
                         ]
-
 
 
 class FitsHeaderTest(unittest.TestCase):
@@ -62,7 +61,6 @@ class FitsHeaderTest(unittest.TestCase):
 
         outputDir = os.path.join(getPackageDir('sims_GalSimInterface'), 'tests',
                                  'scratchSpace')
-
 
         lsst_cat_name = os.path.join(outputDir, 'fits_test_lsst_cat.txt')
         lsst_cat_root = os.path.join(outputDir, 'fits_test_lsst_image')
@@ -141,8 +139,10 @@ def suite():
 
     return unittest.TestSuite(suites)
 
+
 def run(shouldExit = False):
     utilsTests.run(suite(), shouldExit)
+
 
 if __name__ == "__main__":
     run(True)

--- a/tests/testGalSimPhoSimCatalogs.py
+++ b/tests/testGalSimPhoSimCatalogs.py
@@ -10,8 +10,6 @@ from lsst.sims.catalogs.generation.db import fileDBObject
 from lsst.sims.GalSimInterface import GalSimPhoSimGalaxies, GalSimPhoSimStars, GalSimPhoSimAgn
 from lsst.sims.GalSimInterface import SNRdocumentPSF
 from lsst.sims.catUtils.exampleCatalogDefinitions import PhoSimCatalogSersic2D, PhoSimCatalogPoint, PhoSimCatalogZPoint
-from lsst.obs.lsstSim import LsstSimMapper
-
 
 
 class GalSimPhoSimTest(unittest.TestCase):
@@ -81,12 +79,11 @@ class GalSimPhoSimTest(unittest.TestCase):
             for ix in range(cls.n_objects):
                 output_file.write('%d %f %f %f %f Const.79E06.002Z.spec %f %f %f %f %f %f %f %f %f %f %f %f %f %f %f\n' %
                                   (ix, ra[ix], dec[ix], np.degrees(ra[ix]), np.degrees(dec[ix]),
-                                  magNorm[ix], redshift[ix],
-                                  max(majorAxis[ix], minorAxis[ix]), min(majorAxis[ix], minorAxis[ix]),
-                                  positionAngle[ix], hlr[ix], sindex[ix], internalAv[ix], internalRv[ix],
-                                  galacticAv[ix], galacticRv[ix],
-                                  properMotionRa[ix], properMotionDec[ix], radialVelocity[ix], parallax[ix]))
-
+                                   magNorm[ix], redshift[ix],
+                                   max(majorAxis[ix], minorAxis[ix]), min(majorAxis[ix], minorAxis[ix]),
+                                   positionAngle[ix], hlr[ix], sindex[ix], internalAv[ix], internalRv[ix],
+                                   galacticAv[ix], galacticRv[ix],
+                                   properMotionRa[ix], properMotionDec[ix], radialVelocity[ix], parallax[ix]))
 
         # generate some galaxy disk data
         redshift = np.random.random_sample(cls.n_objects)*1.5
@@ -114,12 +111,11 @@ class GalSimPhoSimTest(unittest.TestCase):
             for ix in range(cls.n_objects):
                 output_file.write('%d %f %f %f %f Inst.79E06.02Z.spec %f %f %f %f %f %f %f %f %f %f %f %f %f %f %f\n' %
                                   (ix, ra[ix], dec[ix], np.degrees(ra[ix]), np.degrees(dec[ix]),
-                                  magNorm[ix], redshift[ix],
-                                  max(majorAxis[ix], minorAxis[ix]), min(majorAxis[ix], minorAxis[ix]),
-                                  positionAngle[ix], hlr[ix], sindex[ix], internalAv[ix], internalRv[ix],
-                                  galacticAv[ix], galacticRv[ix],
-                                  properMotionRa[ix], properMotionDec[ix], radialVelocity[ix], parallax[ix]))
-
+                                   magNorm[ix], redshift[ix],
+                                   max(majorAxis[ix], minorAxis[ix]), min(majorAxis[ix], minorAxis[ix]),
+                                   positionAngle[ix], hlr[ix], sindex[ix], internalAv[ix], internalRv[ix],
+                                   galacticAv[ix], galacticRv[ix],
+                                   properMotionRa[ix], properMotionDec[ix], radialVelocity[ix], parallax[ix]))
 
         # generate some agn data
         redshift = np.random.random_sample(cls.n_objects)*1.5
@@ -147,11 +143,11 @@ class GalSimPhoSimTest(unittest.TestCase):
             for ix in range(cls.n_objects):
                 output_file.write('%d %f %f %f %f agn.spec %f %f %f %f %f %f %f %f %f %f %f %f %f %f %f\n' %
                                   (ix, ra[ix], dec[ix], np.degrees(ra[ix]), np.degrees(dec[ix]),
-                                  magNorm[ix], redshift[ix],
-                                  max(majorAxis[ix], minorAxis[ix]), min(majorAxis[ix], minorAxis[ix]),
-                                  positionAngle[ix], hlr[ix], sindex[ix], internalAv[ix], internalRv[ix],
-                                  galacticAv[ix], galacticRv[ix],
-                                  properMotionRa[ix], properMotionDec[ix], radialVelocity[ix], parallax[ix]))
+                                   magNorm[ix], redshift[ix],
+                                   max(majorAxis[ix], minorAxis[ix]), min(majorAxis[ix], minorAxis[ix]),
+                                   positionAngle[ix], hlr[ix], sindex[ix], internalAv[ix], internalRv[ix],
+                                   galacticAv[ix], galacticRv[ix],
+                                   properMotionRa[ix], properMotionDec[ix], radialVelocity[ix], parallax[ix]))
 
         # generate some star data
         redshift = np.random.random_sample(cls.n_objects)*1.5
@@ -179,12 +175,11 @@ class GalSimPhoSimTest(unittest.TestCase):
             for ix in range(cls.n_objects):
                 output_file.write('%d %f %f %f %f km30_5000.fits_g10_5040 %f %f %f %f %f %f %f %f %f %f %f %f %f %f %f\n' %
                                   (ix, ra[ix], dec[ix], np.degrees(ra[ix]), np.degrees(dec[ix]),
-                                  magNorm[ix], redshift[ix],
-                                  max(majorAxis[ix], minorAxis[ix]), min(majorAxis[ix], minorAxis[ix]),
-                                  positionAngle[ix], hlr[ix], sindex[ix], internalAv[ix], internalRv[ix],
-                                  galacticAv[ix], galacticRv[ix],
-                                  properMotionRa[ix], properMotionDec[ix], radialVelocity[ix], parallax[ix]))
-
+                                   magNorm[ix], redshift[ix],
+                                   max(majorAxis[ix], minorAxis[ix]), min(majorAxis[ix], minorAxis[ix]),
+                                   positionAngle[ix], hlr[ix], sindex[ix], internalAv[ix], internalRv[ix],
+                                   galacticAv[ix], galacticRv[ix],
+                                   properMotionRa[ix], properMotionDec[ix], radialVelocity[ix], parallax[ix]))
 
     @classmethod
     def tearDownClass(cls):
@@ -199,7 +194,6 @@ class GalSimPhoSimTest(unittest.TestCase):
 
         if os.path.exists(cls.star_name):
             os.unlink(cls.star_name)
-
 
     def testGalSimPhoSimCat(self):
         """
@@ -298,8 +292,10 @@ def suite():
 
     return unittest.TestSuite(suites)
 
+
 def run(shouldExit = False):
     utilsTests.run(suite(), shouldExit)
+
 
 if __name__ == "__main__":
     run(True)

--- a/tests/testGalSimPhoSimCatalogs.py
+++ b/tests/testGalSimPhoSimCatalogs.py
@@ -28,13 +28,9 @@ class GalSimPhoSimTest(unittest.TestCase):
         np.random.seed(45)
         pointingRA = 45.2
         pointingDec = -31.6
-        phoSimMetaData = {'pointingRA': (np.radians(pointingRA), np.dtype(np.float)),
-                          'pointingDec': (np.radians(pointingDec), np.dtype(np.float)),
-                          'Opsim_rotskypos': (1.2, np.dtype(np.float)),
-                          'Opsim_filter': ('r', np.dtype(str)),
-                          'Opsim_expmjd': (57341.6, np.dtype(np.float))
-                          }
-        cls.obs = ObservationMetaData(phoSimMetaData=phoSimMetaData,
+
+        cls.obs = ObservationMetaData(pointingRA=pointingRA, pointingDec=pointingDec,
+                                      rotSkyPos=1.2, bandpassName='r', mjd=57341.5,
                                       boundLength=0.1, boundType='circle')
 
         cls.dtype = np.dtype([('id', int),
@@ -282,7 +278,7 @@ class GalSimPhoSimTest(unittest.TestCase):
                 galsim_lines = galsim_input.readlines()
                 phosim_lines = phosim_input.readlines()
                 self.assertEqual(len(galsim_lines), len(phosim_lines))
-                self.assertEqual(len(galsim_lines), 4*self.n_objects+5)
+                self.assertEqual(len(galsim_lines), 4*self.n_objects+8)
                 for line in galsim_lines:
                     self.assertIn(line, phosim_lines)
                 for line in phosim_lines:


### PR DESCRIPTION
This pull request re-factors the way we handle PhoSim header information in ObservationMetaData.  Instead of taking all of the header information from ObservationMetaData.phoSimMetaData, pointing information, date, rotSkyPos, and bandpass are taken from the appropriate ObservationMetaData member variables.  phoSimMetaData only exists to store additional information that may have come from an Opsim pointing (or from user input).

A method write_phoSim_header() is added to the PhoSim InstanceCatalog classes in sims_catUtils to parse this new API.

ObservationMetaDataGenerator.py is also updated.

There are pull requests in

sims_utils
sims_catalogs_generation
sims_catUtils
sims_GalSimInterface