### PR TITLE
Feature/sim 2096/phosim interface

### DIFF
--- a/python/lsst/sims/GalSimInterface/galSimCatalogs.py
+++ b/python/lsst/sims/GalSimInterface/galSimCatalogs.py
@@ -188,7 +188,7 @@ class GalSimBase(InstanceCatalog, CameraCoords):
         sims_sed_library
         """
         #copied from the phoSim catalogs
-        return numpy.array([self.specFileMap[k] if self.specFileMap.has_key(k) else None
+        return numpy.array([self.specFileMap[k] if k in self.specFileMap else None
                          for k in self.column_by_name('sedFilename')])
 
     def _calculateGalSimSeds(self):

--- a/python/lsst/sims/GalSimInterface/galSimDetector.py
+++ b/python/lsst/sims/GalSimInterface/galSimDetector.py
@@ -537,11 +537,11 @@ class GalSimDetector(object):
 
                 obshistid = 9999
 
-                if self.obs_metadata.phoSimMetaData is not None:
-                    if 'Opsim_obshistid' in self.obs_metadata.phoSimMetaData:
+                if self.obs_metadata.OpsimMetaData is not None:
+                    if 'obshistID' in self.obs_metadata.OpsimMetaData:
                         self._wcs.fitsHeader.set("OBSID",
-                                                 self.obs_metadata.phoSimMetaData['Opsim_obshistid'])
-                        obshistid = self.obs_metadata.phoSimMetaData['Opsim_obshistid']
+                                                 self.obs_metadata.OpsimMetaData['obshistID'])
+                        obshistid = self.obs_metadata.OpsimMetaData['obshistID']
 
                 bp = self.obs_metadata.bandpass
                 if not isinstance(bp, list) and not isinstance(bp, np.ndarray):

--- a/tests/testFitsHeaders.py
+++ b/tests/testFitsHeaders.py
@@ -76,7 +76,7 @@ class FitsHeaderTest(unittest.TestCase):
                                   boundLength=0.1, boundType='circle',
                                   mjd=58000.0, rotSkyPos=14.0, bandpassName='u')
 
-        obs.phoSimMetaData = {'Opsim_obshistid': 112}
+        obs.OpsimMetaData = {'obshistID': 112}
 
         dbFileName = os.path.join(outputDir, 'fits_test_db.dat')
         create_text_catalog(obs, dbFileName, np.array([30.0]), np.array([30.0]), [22.0])

--- a/tests/testGalSimPhoSimCatalogs.py
+++ b/tests/testGalSimPhoSimCatalogs.py
@@ -217,11 +217,13 @@ class GalSimPhoSimTest(unittest.TestCase):
         gs_cat = GalSimPhoSimGalaxies(db, obs_metadata=self.obs)
         gs_cat.bandpassNames = self.obs.bandpass
         gs_cat.PSF = SNRdocumentPSF()
+        gs_cat.phoSimHeaderMap = {}
         gs_cat.write_catalog(galsim_cat_name)
 
         gs_cat_0 = gs_cat
 
         ps_cat = PhoSimCatalogSersic2D(db, obs_metadata=self.obs)
+        ps_cat.phoSimHeaderMap = {}
         ps_cat.write_catalog(phosim_cat_name)
 
         db = fileDBObject(self.disk_name, dtype=self.dtype, runtable='test_disks', idColKey='id')

--- a/tests/testGalSimPhoSimCatalogs.py
+++ b/tests/testGalSimPhoSimCatalogs.py
@@ -277,7 +277,7 @@ class GalSimPhoSimTest(unittest.TestCase):
                 galsim_lines = galsim_input.readlines()
                 phosim_lines = phosim_input.readlines()
                 self.assertEqual(len(galsim_lines), len(phosim_lines))
-                self.assertEqual(len(galsim_lines), 4*self.n_objects+8)
+                self.assertEqual(len(galsim_lines), 4*self.n_objects+7)
                 for line in galsim_lines:
                     self.assertIn(line, phosim_lines)
                 for line in phosim_lines:


### PR DESCRIPTION
A new PhoSim InstanceCatalog API has been published here

https://bitbucket.org/phosim/phosim_release/wiki/Instance%20Catalog

This required a re-working of our CatSim-PhoSim interface.  Under this pull request, whenever a user creates an ObservationMetaData using the ObservationMetaDataGenerator, all of the OpSim columns associated with the pointing will be stored in a dict called `OpsimMetaData`.  The mapping between these OpSim columns and the header parameters expected by PhoSim will be handled by a dict called `phoSimHeaderMap` which is assigned to the InstanceCatalog before writing it.  If no `phoSimHeaderMap` is specified, an error is thrown whose message explains the way the header map should work.  Even if users do not want to map any extra columns (i.e. anything beyond RA, Dec, Alt, Az, MJD, rotSkyPos, and filter, which ObservationMetaData handles automatically), they must specify an empty dict as the `phoSimHeaderMap`.  This is to prevent users from doing something they did not intend (since PhoSim will accept nonsense or incomplete header parameters without failing).

This required changes to

sims_utils
sims_catalogs
sims_catUtils
sims_GalSimInterface