### PR TITLE
U/danielsf/fix rotskypos

### DIFF
--- a/examples/notebooks/GalSimTutorialCustomCatalog.ipynb
+++ b/examples/notebooks/GalSimTutorialCustomCatalog.ipynb
@@ -264,7 +264,7 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "raw",
    "metadata": {},
    "source": [
     "<b>Creating a `GalSimCatalog`</b>\n",
@@ -294,7 +294,7 @@
     "* `componentList` -- this is a place holder for future functionality; just initialize it as an empty list\n",
     "\n",
     "\n",
-    "* `camera` -- this is the `afwCameraGeom` object that store the information about your camera.  Below, we will use a model of the LSST camera.\n",
+    "* `camera_wrapper` -- this is an instantiation of the `GalSimCameraWrapper` class which can be imported from `lsst.sims.GalSimInterfave`.  It wraps an `afwCameraGeom` object that stores the information about your camera.  Below, we will use a model of the LSST camera.  Note: you can also add the `camera_wrapper` after instantiation, if you would rather not define it in your class declaration.\n",
     "\n",
     "\n",
     "* `PSF` -- GalSim draws point sources by convolving them with a PSF.  There are a set of specific classes written for this purpose and defined in `sims_GalSimInterface/python/lsst/sims/GalSimInterface/galSimPSF.py`.  For now, we will use one of those pre-written PSF classes.  Below, we will show you how to write your own PSF class and use it to generate images.\n",
@@ -322,7 +322,7 @@
     "import os\n",
     "from lsst.sims.GalSimInterface import GalSimStars, SNRdocumentPSF\n",
     "from lsst.sims.photUtils import PhotometricParameters\n",
-    "from lsst.obs.lsstSim import LsstSimMapper\n",
+    "from lsst.sims.GalSimInterface import LSSTCameraWrapper\n",
     "\n",
     "class PointSourceGalSimCatalog(GalSimStars):\n",
     "\n",
@@ -334,7 +334,7 @@
     "    bandpassNames = ['y']\n",
     "    bandpassRoot = 'myCustomBandpass_'\n",
     "    componentList = []\n",
-    "    camera = LsstSimMapper().camera\n",
+    "    camera_wrapper = LSSTCameraWrapper()\n",
     "\n",
     "    def get_sedFilepath(self):\n",
     "        # this method would be more complicated if there were sub-directories\n",
@@ -761,21 +761,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/examples/scripts/galSimCompoundGenerator.py
+++ b/examples/scripts/galSimCompoundGenerator.py
@@ -10,6 +10,7 @@ from lsst.utils import getPackageDir
 from lsst.sims.catalogs.db import CatalogDBObject
 from lsst.sims.catUtils.utils import ObservationMetaDataGenerator
 from lsst.sims.catUtils.baseCatalogModels import StarObj, GalaxyBulgeObj, GalaxyDiskObj, GalaxyAgnObj
+from lsst.sims.GalSimInterface import LSSTCameraWrapper
 from lsst.sims.GalSimInterface import SNRdocumentPSF, GalSimStars, GalSimGalaxies, \
                                                GalSimAgn
 
@@ -24,22 +25,11 @@ class testGalSimStars(GalSimStars):
     #PSF defined in galSimInterface/galSimUtilities.py
     PSF = SNRdocumentPSF()
 
-    #If you want to use the LSST camera, uncomment the line below.
-    #You can similarly assign any camera object you want here
-    #camera = LsstSimMapper().camera
-
-
 
 class testGalSimGalaxies(GalSimGalaxies):
     bandpassNames = ['u', 'g']
 
     PSF = SNRdocumentPSF()
-
-    #If you want to use the LSST camera, uncomment the line below.
-    #You can similarly assign any camera object you want here
-    #camera = LsstSimMapper().camera
-
-
 
 
 class testGalSimAgn(GalSimAgn):
@@ -47,11 +37,6 @@ class testGalSimAgn(GalSimAgn):
 
     #defined in galSimInterface/galSimUtilities.py
     PSF = SNRdocumentPSF()
-
-    #If you want to use the LSST camera, uncomment the line below.
-    #You can similarly assign any camera object you want here
-    #camera = LsstSimMapper().camera
-
 
 
 #select an OpSim pointing
@@ -65,6 +50,7 @@ stars = CatalogDBObject.from_objid('allstars')
 
 #now append a bunch of objects with 2D sersic profiles to our output file
 stars_galSim = testGalSimStars(stars, obs_metadata=obs_metadata)
+stars_galSim.camera_wrapper = LSSTCameraWrapper()
 
 catName = 'galSim_compound_example.txt'
 stars_galSim.write_catalog(catName, chunk_size=100)

--- a/examples/scripts/galSimGalaxyBulgeGenerator.py
+++ b/examples/scripts/galSimGalaxyBulgeGenerator.py
@@ -9,6 +9,7 @@ from lsst.sims.catalogs.db import CatalogDBObject
 from lsst.sims.catUtils.utils import ObservationMetaDataGenerator
 from lsst.sims.catUtils.baseCatalogModels import GalaxyBulgeObj
 from lsst.sims.GalSimInterface import GalSimGalaxies, SNRdocumentPSF
+from lsst.sims.GalSimInterface import LSSTCameraWrapper
 
 #if you want to use the actual LSST camera
 #from lsst.obs.lsstSim import LsstSimMapper
@@ -18,11 +19,6 @@ class testGalSimGalaxies(GalSimGalaxies):
     bandpassNames = ['u','g']
 
     PSF = SNRdocumentPSF()
-
-    #If you want to use the LSST camera, uncomment the line below.
-    #You can similarly assign any camera object you want here
-    #camera = LsstSimMapper().camera
-
 
 #select an OpSim pointing
 opsimdb = os.path.join(getPackageDir('sims_data'), 'OpSimData',
@@ -36,6 +32,7 @@ gals = CatalogDBObject.from_objid('galaxyBulge')
 
 #now append a bunch of objects with 2D sersic profiles to our output file
 galaxy_galSim = testGalSimGalaxies(gals, obs_metadata=obs_metadata)
+galaxy_galSim.camera_wrapper = LSSTCameraWrapper()
 
 galaxy_galSim.write_catalog('galSim_bulge_example.txt', chunk_size=10000)
 galaxy_galSim.write_images(nameRoot='bulge')

--- a/examples/scripts/galSimGalaxyBulgeWithNoise.py
+++ b/examples/scripts/galSimGalaxyBulgeWithNoise.py
@@ -12,6 +12,7 @@ from lsst.sims.GalSimInterface import GalSimGalaxies, ExampleCCDNoise, \
                                                SNRdocumentPSF
 
 from lsst.sims.photUtils import LSSTdefaults
+from lsst.sims.GalSimInterface import LSSTCameraWrapper
 
 #if you want to use the actual LSST camera
 #from lsst.obs.lsstSim import LsstSimMapper
@@ -19,10 +20,6 @@ from lsst.sims.photUtils import LSSTdefaults
 class testGalSimGalaxiesNoiseless(GalSimGalaxies):
     #only draw images for u and g bands (for speed)
     bandpassNames = ['u','g']
-
-    #If you want to use the LSST camera, uncomment the line below.
-    #You can similarly assign any camera object you want here
-    #camera = LsstSimMapper().camera
 
     PSF = SNRdocumentPSF()
 
@@ -54,6 +51,7 @@ gals = CatalogDBObject.from_objid('galaxyBulge')
 
 #now append a bunch of objects with 2D sersic profiles to our output file
 gal_noiseless = testGalSimGalaxiesNoiseless(gals, obs_metadata=obs_metadata)
+gal_noiseless.camera_wrapper = LSSTCameraWrapper()
 
 gal_noiseless.write_catalog('galSim_NoiselessGalaxies_example.txt', chunk_size=10000)
 gal_noiseless.write_images(nameRoot='noiselessGalaxies')

--- a/examples/scripts/galSimStarGenerator.py
+++ b/examples/scripts/galSimStarGenerator.py
@@ -8,6 +8,7 @@ from lsst.sims.catalogs.db import CatalogDBObject
 from lsst.sims.catUtils.utils import ObservationMetaDataGenerator
 from lsst.sims.catUtils.baseCatalogModels import StarObj
 from lsst.sims.GalSimInterface import SNRdocumentPSF, GalSimStars
+from lsst.sims.GalSimInterface import LSSTCameraWrapper
 
 #if you want to use the actual LSST camera
 #from lsst.obs.lsstSim import LsstSimMapper
@@ -18,11 +19,6 @@ class testGalSimStars(GalSimStars):
 
     #defined in galSimInterface/galSimUtilities.py
     PSF = SNRdocumentPSF()
-
-    #If you want to use the LSST camera, uncomment the line below.
-    #You can similarly assign any camera object you want here
-    #camera = LsstSimMapper().camera
-
 
 
 #select an OpSim pointing
@@ -38,6 +34,7 @@ stars = CatalogDBObject.from_objid('allstars')
 
 #now append a bunch of objects with 2D sersic profiles to our output file
 stars_galSim = testGalSimStars(stars, obs_metadata=obs_metadata)
+stars_galSim.camera_wrapper = LSSTCameraWrapper()
 
 stars_galSim.write_catalog('galSim_star_example.txt', chunk_size=100)
 stars_galSim.write_images(nameRoot='star')

--- a/examples/scripts/galSimStarsWithNoise.py
+++ b/examples/scripts/galSimStarsWithNoise.py
@@ -10,6 +10,7 @@ from lsst.sims.catUtils.utils import ObservationMetaDataGenerator
 from lsst.sims.catUtils.baseCatalogModels import StarObj, OpSim3_61DBObject
 from lsst.sims.GalSimInterface import GalSimStars, SNRdocumentPSF, ExampleCCDNoise
 from lsst.sims.photUtils import LSSTdefaults
+from lsst.sims.GalSimInterface import LSSTCameraWrapper
 
 #if you want to use the actual LSST camera
 #from lsst.obs.lsstSim import LsstSimMapper
@@ -20,11 +21,6 @@ class testGalSimStarsNoiseless(GalSimStars):
 
     #defined in galSimInterface/galSimUtilities.py
     PSF = SNRdocumentPSF()
-
-    #If you want to use the LSST camera, uncomment the line below.
-    #You can similarly assign any camera object you want here
-    #camera = LsstSimMapper().camera
-
 
 
 class testGalSimStarsWithNoise(testGalSimStarsNoiseless):
@@ -56,6 +52,7 @@ stars = CatalogDBObject.from_objid('allstars')
 
 #now append a bunch of objects with 2D sersic profiles to our output file
 stars_noiseless = testGalSimStarsNoiseless(stars, obs_metadata=obs_metadata)
+stars_noiseless.camera_wrapper = LSSTCameraWrapper()
 
 stars_noiseless.write_catalog('galSim_NoiselessStars_example.txt', chunk_size=10000)
 stars_noiseless.write_images(nameRoot='noiselessStars')

--- a/python/lsst/sims/GalSimInterface/__init__.py
+++ b/python/lsst/sims/GalSimInterface/__init__.py
@@ -1,3 +1,4 @@
+from .galSimCameraWrapper import *
 from .galSimDetector import *
 from .galSimCelestialObject import *
 from .galSimNoiseAndBackground import *

--- a/python/lsst/sims/GalSimInterface/galSimCameraWrapper.py
+++ b/python/lsst/sims/GalSimInterface/galSimCameraWrapper.py
@@ -1,0 +1,675 @@
+"""
+This module provides wrappers for afwCameraGeom camera objects.
+This is necessary because of the 90-degree rotation between
+how DM defines pixel coordinates and how the Camera team (and
+thus PhoSim) defines pixel coordinates.  Recall
+
+Camera +y = DM +x
+Camera +x = DM -y
+
+Because we want ImSim images to have the same WCS conventions
+as PhoSim e-images, we need to apply this rotation to the
+mappings between RA, Dec and pixel coordinates.  We may not
+wish to do that for arbitrary cameras, so we will give
+users the ability to apply a no-op wrapper to their cameras.
+"""
+
+import numpy as np
+from lsst.afw.cameraGeom import FOCAL_PLANE, PIXELS, TAN_PIXELS
+from lsst.afw.cameraGeom import PUPIL
+import lsst.afw.geom as afwGeom
+import lsst.sims.coordUtils as coordUtils
+import lsst.sims.utils as simsUtils
+
+__all__ = ["GalSimCameraWrapper", "LSSTCameraWrapper"]
+
+class GalSimCameraWrapper(object):
+    """
+    This is a no-op camera wrapper.
+    """
+
+    def __init__(self, camera):
+        """
+        Parameters
+        ----------
+        camera is an instantiation of an afwCameraGeom camera
+        """
+        self._camera = camera
+
+    @property
+    def camera(self):
+        return self._camera
+
+    def getBBox(self, detector_name):
+        """
+        Return the bounding box for the detector named by detector_name
+        """
+        return self._camera[detector_name].getBBox()
+
+    def getCenterPixel(self, detector_name):
+         """
+         Return the central pixel for the detector named by detector_name
+         """
+         centerPoint = self._camera[detector_name].getCenter(FOCAL_PLANE)
+         pixelSystem = self._camera[detector_name].makeCameraSys(PIXELS)
+         return self._camera.transform(centerPoint, pixelSystem).getPoint()
+
+    def getCenterPupil(self, detector_name):
+        dd = self._camera[detector_name]
+        cs = dd.makeCameraSys(PUPIL)
+        return self._camera.transform(dd.getCenter(FOCAL_PLANE), cs).getPoint()
+
+    def getCornerPupilList(self, detector_name):
+        dd = self._camera[detector_name]
+        pupilSystem = dd.makeCameraSys(PUPIL)
+        cornerPointList = dd.getCorners(FOCAL_PLANE)
+        pupil_point_list = []
+        for cornerPoint in cornerPointList:
+            cameraPoint = dd.makeCameraPoint(cornerPoint, FOCAL_PLANE)
+            cameraPointPupil = self._camera.transform(cameraPoint, pupilSystem).getPoint()
+            pupil_point_list.append(cameraPointPupil)
+        return pupil_point_list
+
+    def getTanPixelBounds(self, detector_name):
+        afwDetector = self._camera[detector_name]
+        tanPixelSystem = afwDetector.makeCameraSys(TAN_PIXELS)
+        xPixMin = None
+        xPixMax = None
+        yPixMin = None
+        yPixMax = None
+        cornerPointList = afwDetector.getCorners(FOCAL_PLANE)
+        for cornerPoint in cornerPointList:
+            cameraPoint = self._camera.transform(afwDetector.makeCameraPoint(cornerPoint, FOCAL_PLANE),
+                                                 tanPixelSystem).getPoint()
+
+            xx = cameraPoint.getX()
+            yy = cameraPoint.getY()
+            if xPixMin is None or xx < xPixMin:
+                xPixMin = xx
+            if xPixMax is None or xx > xPixMax:
+                xPixMax = xx
+            if yPixMin is None or yy < yPixMin:
+                yPixMin = yy
+            if yPixMax is None or yy > yPixMax:
+                yPixMax = yy
+
+        return xPixMin, xPixMax, yPixMin, yPixMax
+
+    def pixelCoordsFromPupilCoords(self, xPupil, yPupil, chipName=None,
+                                   includeDistortion=True):
+        """
+        Get the pixel positions (or nan if not on a chip) for objects based
+        on their pupil coordinates.
+
+        @param [in] xPupil is the x pupil coordinates in radians.
+        Can be either a float or a numpy array.
+
+        @param [in] yPupil is the y pupil coordinates in radians.
+        Can be either a float or a numpy array.
+
+        @param [in] chipName designates the names of the chips on which the pixel
+        coordinates will be reckoned.  Can be either single value, an array, or None.
+        If an array, there must be as many chipNames as there are (RA, Dec) pairs.
+        If a single value, all of the pixel coordinates will be reckoned on the same
+        chip.  If None, this method will calculate which chip each(RA, Dec) pair actually
+        falls on, and return pixel coordinates for each (RA, Dec) pair on the appropriate
+        chip.  Default is None.
+
+        @param [in] includeDistortion is a boolean.  If True (default), then this method will
+        return the true pixel coordinates with optical distortion included.  If False, this
+        method will return TAN_PIXEL coordinates, which are the pixel coordinates with
+        estimated optical distortion removed.  See the documentation in afw.cameraGeom for more
+        details.
+
+        @param [out] a 2-D numpy array in which the first row is the x pixel coordinate
+        and the second row is the y pixel coordinate
+        """
+        return coordUtils.pixelCoordsFromPupilCoords(xPupil, yPupil, chipName=chipName,
+                                                     camera=self._camera,
+                                                     includeDistortion=includeDistortion)
+
+    def pupilCoordsFromPixelCoords(self, xPix, yPix, chipName, includeDistortion=True):
+
+        """
+        Convert pixel coordinates into pupil coordinates
+
+        @param [in] xPix is the x pixel coordinate of the point.
+        Can be either a float or a numpy array.
+
+        @param [in] yPix is the y pixel coordinate of the point.
+        Can be either a float or a numpy array.
+
+        @param [in] chipName is the name of the chip(s) on which the pixel coordinates
+        are defined.  This can be a list (in which case there should be one chip name
+        for each (xPix, yPix) coordinate pair), or a single value (in which case, all
+        of the (xPix, yPix) points will be reckoned on that chip).
+
+        @param [in] includeDistortion is a boolean.  If True (default), then this method will
+        expect the true pixel coordinates with optical distortion included.  If False, this
+        method will expect TAN_PIXEL coordinates, which are the pixel coordinates with
+        estimated optical distortion removed.  See the documentation in afw.cameraGeom for more
+        details.
+
+        @param [out] a 2-D numpy array in which the first row is the x pupil coordinate
+        and the second row is the y pupil coordinate (both in radians)
+        """
+        return coordUtils.pupilCoordsFromPixelCoords(xPix, yPix, chipName,
+                                                     camera=self._camera,
+                                                     includeDistortion=includeDistortion)
+
+    def _raDecFromPixelCoords(self, xPix, yPix, chipName, obs_metadata,
+                              epoch=2000.0, includeDistortion=True):
+        """
+        Convert pixel coordinates into RA, Dec
+
+        @param [in] xPix is the x pixel coordinate.  It can be either
+        a float or a numpy array.
+
+        @param [in] yPix is the y pixel coordinate.  It can be either
+        a float or a numpy array.
+
+        @param [in] chipName is the name of the chip(s) on which the pixel coordinates
+        are defined.  This can be a list (in which case there should be one chip name
+        for each (xPix, yPix) coordinate pair), or a single value (in which case, all
+        of the (xPix, yPix) points will be reckoned on that chip).
+
+        @param [in] camera is an afw.CameraGeom.camera object defining the camera
+
+        @param [in] obs_metadata is an ObservationMetaData defining the pointing
+
+        @param [in] epoch is the mean epoch in years of the celestial coordinate system.
+        Default is 2000.
+
+        @param [in] includeDistortion is a boolean.  If True (default), then this method will
+        expect the true pixel coordinates with optical distortion included.  If False, this
+        method will expect TAN_PIXEL coordinates, which are the pixel coordinates with
+        estimated optical distortion removed.  See the documentation in afw.cameraGeom for more
+        details.
+
+        @param [out] a 2-D numpy array in which the first row is the RA coordinate
+        and the second row is the Dec coordinate (both in radians; in the
+        International Celestial Reference System)
+
+        WARNING: This method does not account for apparent motion due to parallax.
+        This method is only useful for mapping positions on a theoretical focal plane
+        to positions on the celestial sphere.
+        """
+
+        return coordUtils._raDecFromPixelCoords(xPix, yPix, chipName,
+                                                camera=self._camera,
+                                                obs_metadata=obs_metadata,
+                                                epoch=epoch,
+                                                includeDistortion=includeDistortion)
+
+    def raDecFromPixelCoords(self, xPix, yPix, chipName, obs_metadata,
+                             epoch=2000.0, includeDistortion=True):
+
+        return coordUtils.raDecFromPixelCoords(xPix, yPix, chipName, obs_metadata,
+                                               epoch=2000.0, includeDistortion=True)
+
+    def _pixelCoordsFromRaDec(self, ra, dec, pm_ra=None, pm_dec=None,
+                              parallax=None, v_rad=None,
+                              obs_metadata=None,
+                              chipName=None,
+                              epoch=2000.0, includeDistortion=True):
+        """
+        Get the pixel positions (or nan if not on a chip) for objects based
+        on their RA, and Dec (in radians)
+
+        @param [in] ra is in radians in the International Celestial Reference System.
+        Can be either a float or a numpy array.
+
+        @param [in] dec is in radians in the International Celestial Reference System.
+        Can be either a float or a numpy array.
+
+        @param [in] pm_ra is proper motion in RA multiplied by cos(Dec) (radians/yr)
+        Can be a numpy array or a number or None (default=None).
+
+        @param [in] pm_dec is proper motion in dec (radians/yr)
+        Can be a numpy array or a number or None (default=None).
+
+        @param [in] parallax is parallax in radians
+        Can be a numpy array or a number or None (default=None).
+
+        @param [in] v_rad is radial velocity (km/s)
+        Can be a numpy array or a number or None (default=None).
+
+        @param [in] obs_metadata is an ObservationMetaData characterizing the telescope
+        pointing.
+
+        @param [in] epoch is the epoch in Julian years of the equinox against which
+        RA is measured.  Default is 2000.
+
+        @param [in] chipName designates the names of the chips on which the pixel
+        coordinates will be reckoned.  Can be either single value, an array, or None.
+        If an array, there must be as many chipNames as there are (RA, Dec) pairs.
+        If a single value, all of the pixel coordinates will be reckoned on the same
+        chip.  If None, this method will calculate which chip each(RA, Dec) pair actually
+        falls on, and return pixel coordinates for each (RA, Dec) pair on the appropriate
+        chip.  Default is None.
+
+        @param [in] includeDistortion is a boolean.  If True (default), then this method will
+        return the true pixel coordinates with optical distortion included.  If False, this
+        method will return TAN_PIXEL coordinates, which are the pixel coordinates with
+        estimated optical distortion removed.  See the documentation in afw.cameraGeom for more
+        details.
+
+        @param [out] a 2-D numpy array in which the first row is the x pixel coordinate
+        and the second row is the y pixel coordinate
+        """
+
+        return coordUtils._pixelCoordsFromRaDec(ra, dec, pm_ra=pm_ra, pm_dec=pm_dec,
+                                                parallax=parallax, v_rad=v_rad,
+                                                obs_metadata=obs_metadata,
+                                                chipName=chipName, camera=self._camera,
+                                                epoch=epoch, includeDistortion=includeDistortion)
+
+    def pixelCoordsFromRaDec(self, ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=None,
+                             obs_metadata=None,
+                             chipName=None, camera=None,
+                             epoch=2000.0, includeDistortion=True):
+        """
+        Get the pixel positions (or nan if not on a chip) for objects based
+        on their RA, and Dec (in degrees)
+
+        @param [in] ra is in degrees in the International Celestial Reference System.
+        Can be either a float or a numpy array.
+
+        @param [in] dec is in degrees in the International Celestial Reference System.
+        Can be either a float or a numpy array.
+
+        @param [in] pm_ra is proper motion in RA multiplied by cos(Dec) (arcsec/yr)
+        Can be a numpy array or a number or None (default=None).
+
+        @param [in] pm_dec is proper motion in dec (arcsec/yr)
+        Can be a numpy array or a number or None (default=None).
+
+        @param [in] parallax is parallax in arcsec
+        Can be a numpy array or a number or None (default=None).
+
+        @param [in] v_rad is radial velocity (km/s)
+        Can be a numpy array or a number or None (default=None).
+
+        @param [in] obs_metadata is an ObservationMetaData characterizing the telescope
+        pointing.
+
+        @param [in] epoch is the epoch in Julian years of the equinox against which
+        RA is measured.  Default is 2000.
+
+        @param [in] chipName designates the names of the chips on which the pixel
+        coordinates will be reckoned.  Can be either single value, an array, or None.
+        If an array, there must be as many chipNames as there are (RA, Dec) pairs.
+        If a single value, all of the pixel coordinates will be reckoned on the same
+        chip.  If None, this method will calculate which chip each(RA, Dec) pair actually
+        falls on, and return pixel coordinates for each (RA, Dec) pair on the appropriate
+        chip.  Default is None.
+
+        @param [in] includeDistortion is a boolean.  If True (default), then this method will
+        return the true pixel coordinates with optical distortion included.  If False, this
+        method will return TAN_PIXEL coordinates, which are the pixel coordinates with
+        estimated optical distortion removed.  See the documentation in afw.cameraGeom for more
+        details.
+
+        @param [out] a 2-D numpy array in which the first row is the x pixel coordinate
+        and the second row is the y pixel coordinate
+        """
+
+        return coordUtils.pixelCoordsFromRaDec(ra, dec, pm_ra=pm_ra, pm_dec=pm_dec,
+                                               parallax=parallax, v_rad=v_rad,
+                                               obs_metadata=obs_metadata,
+                                               chipName=chipName, camera=self._camera,
+                                               epoch=epoch, includeDistortion=includeDistortion)
+
+
+
+class LSSTCameraWrapper(GalSimCameraWrapper):
+
+    def __init__(self):
+        self._camera = coordUtils.lsst_camera()
+
+    def getBBox(self, detector_name):
+        """
+        Return the bounding box for the detector named by detector_name
+        """
+        dm_bbox = self._camera[detector_name].getBBox()
+        dm_min = dm_bbox.getMin()
+        dm_max = dm_bbox.getMax()
+        cam_bbox = afwGeom.Box2I(minimum=afwGeom.coordinates.Point2I(dm_min[1], dm_min[0]),
+                                 maximum=afwGeom.coordinates.Point2I(dm_max[1], dm_max[0]))
+
+        return cam_bbox
+
+    def getCenterPixel(self, detector_name):
+         """
+         Return the central pixel for the detector named by detector_name
+         """
+         centerPoint = self._camera[detector_name].getCenter(FOCAL_PLANE)
+         pixelSystem = self._camera[detector_name].makeCameraSys(PIXELS)
+         centerPixel = self._camera.transform(centerPoint, pixelSystem).getPoint()
+         return afwGeom.coordinates.Point2D(centerPixel.getY(), centerPixel.getX())
+
+    def getTanPixelBounds(self, detector_name):
+        dm_xmin, dm_xmax, dm_ymin, dm_ymax = GalSimCameraWrapper.getTanPixelBounds(self, detector_name)
+        return dm_ymin, dm_ymax, dm_xmin, dm_xmax
+
+    def pixelCoordsFromPupilCoords(self, xPupil, yPupil, chipName=None,
+                                   includeDistortion=True):
+        """
+        Get the pixel positions (or nan if not on a chip) for objects based
+        on their pupil coordinates.
+
+        @param [in] xPupil is the x pupil coordinates in radians.
+        Can be either a float or a numpy array.
+
+        @param [in] yPupil is the y pupil coordinates in radians.
+        Can be either a float or a numpy array.
+
+        @param [in] chipName designates the names of the chips on which the pixel
+        coordinates will be reckoned.  Can be either single value, an array, or None.
+        If an array, there must be as many chipNames as there are (RA, Dec) pairs.
+        If a single value, all of the pixel coordinates will be reckoned on the same
+        chip.  If None, this method will calculate which chip each(RA, Dec) pair actually
+        falls on, and return pixel coordinates for each (RA, Dec) pair on the appropriate
+        chip.  Default is None.
+
+        @param [in] includeDistortion is a boolean.  If True (default), then this method will
+        return the true pixel coordinates with optical distortion included.  If False, this
+        method will return TAN_PIXEL coordinates, which are the pixel coordinates with
+        estimated optical distortion removed.  See the documentation in afw.cameraGeom for more
+        details.
+
+        @param [out] a 2-D numpy array in which the first row is the x pixel coordinate
+        and the second row is the y pixel coordinate
+        """
+        dm_x_pix, dm_y_pix = coordUtils.pixelCoordsFromPupilCoords(xPupil, yPupil,
+                                                                   chipName=chipName,
+                                                                   camera=self._camera,
+                                                                   includeDistortion=includeDistortion)
+
+        cam_y_pix = dm_x_pix
+        if isinstance(chipName, list) or isinstance(chipName, np.ndarray):
+            cam_x_pix = np.zeros(len(dm_y_pix))
+            for ix, (det_name, yy) in enumerate(zip(chipName, dm_y_pix)):
+                center_pix = self.getCenterPixel(det_name)
+                cam_x_pix[ix] = 2.0*center_pix[0]-yy
+        else:
+            center_pix = self.getCenterPixel(chipName)
+            cam_x_pix = 2.0*center_pix[0] - dm_y_pix
+
+        return cam_x_pix, cam_y_pix
+
+    def pupilCoordsFromPixelCoords(self, xPix, yPix, chipName, includeDistortion=True):
+
+        """
+        Convert pixel coordinates into pupil coordinates
+
+        @param [in] xPix is the x pixel coordinate of the point.
+        Can be either a float or a numpy array.
+
+        @param [in] yPix is the y pixel coordinate of the point.
+        Can be either a float or a numpy array.
+
+        @param [in] chipName is the name of the chip(s) on which the pixel coordinates
+        are defined.  This can be a list (in which case there should be one chip name
+        for each (xPix, yPix) coordinate pair), or a single value (in which case, all
+        of the (xPix, yPix) points will be reckoned on that chip).
+
+        @param [in] includeDistortion is a boolean.  If True (default), then this method will
+        expect the true pixel coordinates with optical distortion included.  If False, this
+        method will expect TAN_PIXEL coordinates, which are the pixel coordinates with
+        estimated optical distortion removed.  See the documentation in afw.cameraGeom for more
+        details.
+
+        @param [out] a 2-D numpy array in which the first row is the x pupil coordinate
+        and the second row is the y pupil coordinate (both in radians)
+        """
+        dm_xPix = yPix
+        if isinstance(chipName, list) or isinstance(chipName, np.ndarray):
+            dm_yPix = np.zeros(len(xPix))
+            for ix, (det_name, xx) in enumerate(zip(chipName, xPix)):
+                came_center_pix = self.getCenterPixel(det_name)
+                dm_yPix[ix] = 2.0*cam_center_pix.getX()-xPix[ix]
+        else:
+            cam_center_pix = self.getCenterPixel(chipName)
+            dm_yPix = 2.0*cam_center_pix.getX()-xPix
+        return coordUtils.pupilCoordsFromPixelCoords(dm_xPix, dm_yPix, chipName,
+                                                     camera=coordUtils.lsst_camera(),
+                                                     includeDistortion=includeDistortion)
+
+    def _raDecFromPixelCoords(self, xPix, yPix, chipName, obs_metadata,
+                              epoch=2000.0, includeDistortion=True):
+        """
+        Convert pixel coordinates into RA, Dec
+
+        @param [in] xPix is the x pixel coordinate.  It can be either
+        a float or a numpy array.
+
+        @param [in] yPix is the y pixel coordinate.  It can be either
+        a float or a numpy array.
+
+        @param [in] chipName is the name of the chip(s) on which the pixel coordinates
+        are defined.  This can be a list (in which case there should be one chip name
+        for each (xPix, yPix) coordinate pair), or a single value (in which case, all
+        of the (xPix, yPix) points will be reckoned on that chip).
+
+        @param [in] camera is an afw.CameraGeom.camera object defining the camera
+
+        @param [in] obs_metadata is an ObservationMetaData defining the pointing
+
+        @param [in] epoch is the mean epoch in years of the celestial coordinate system.
+        Default is 2000.
+
+        @param [in] includeDistortion is a boolean.  If True (default), then this method will
+        expect the true pixel coordinates with optical distortion included.  If False, this
+        method will expect TAN_PIXEL coordinates, which are the pixel coordinates with
+        estimated optical distortion removed.  See the documentation in afw.cameraGeom for more
+        details.
+
+        @param [out] a 2-D numpy array in which the first row is the RA coordinate
+        and the second row is the Dec coordinate (both in radians; in the
+        International Celestial Reference System)
+
+        WARNING: This method does not account for apparent motion due to parallax.
+        This method is only useful for mapping positions on a theoretical focal plane
+        to positions on the celestial sphere.
+        """
+
+        if isinstance(chipName, list) or isinstance(chipName, np.ndarray):
+            dm_xPix = yPix
+            dm_yPix = np.zeros(len(xPix))
+            for ix, (det_name, xx) in enumerate(zip(chipName, xPix)):
+                cam_center_pix = self.getCenterPixel(det_name)
+                dm_yPix[ix] = 2.0*cam_center_pix.getX() - xx
+        else:
+            dm_xPix = yPix
+            cam_center_pix = self.getCenterPixel(chipName)
+            dm_yPix = 2.0*cam_center_pix.getX() - xPix
+
+        return coordUtils._raDecFromPixelCoords(dm_xPix, dm_yPix, chipName,
+                                                camera=self._camera,
+                                                obs_metadata=obs_metadata,
+                                                epoch=epoch,
+                                                includeDistortion=includeDistortion)
+
+    def raDecFromPixelCoords(self, xPix, yPix, chipName, obs_metadata,
+                             epoch=2000.0, includeDistortion=True):
+        """
+        Convert pixel coordinates into RA, Dec
+
+        @param [in] xPix is the x pixel coordinate.  It can be either
+        a float or a numpy array.
+
+        @param [in] yPix is the y pixel coordinate.  It can be either
+        a float or a numpy array.
+
+        @param [in] chipName is the name of the chip(s) on which the pixel coordinates
+        are defined.  This can be a list (in which case there should be one chip name
+        for each (xPix, yPix) coordinate pair), or a single value (in which case, all
+        of the (xPix, yPix) points will be reckoned on that chip).
+
+        @param [in] camera is an afw.CameraGeom.camera object defining the camera
+
+        @param [in] obs_metadata is an ObservationMetaData defining the pointing
+
+        @param [in] epoch is the mean epoch in years of the celestial coordinate system.
+        Default is 2000.
+
+        @param [in] includeDistortion is a boolean.  If True (default), then this method will
+        expect the true pixel coordinates with optical distortion included.  If False, this
+        method will expect TAN_PIXEL coordinates, which are the pixel coordinates with
+        estimated optical distortion removed.  See the documentation in afw.cameraGeom for more
+        details.
+
+        @param [out] a 2-D numpy array in which the first row is the RA coordinate
+        and the second row is the Dec coordinate (both in degrees; in the
+        International Celestial Reference System)
+
+        WARNING: This method does not account for apparent motion due to parallax.
+        This method is only useful for mapping positions on a theoretical focal plane
+        to positions on the celestial sphere.
+        """
+
+        _ra, _dec = self._raDecFromPixelCoords(xPix, yPix, chipName, obs_metadata,
+                                               epoch=2000.0, includeDistortion=True)
+
+        return np.degrees(_ra), np.degrees(_dec)
+
+    def _pixelCoordsFromRaDec(self, ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=None,
+                              obs_metadata=None,
+                              chipName=None,
+                              epoch=2000.0, includeDistortion=True):
+        """
+        Get the pixel positions (or nan if not on a chip) for objects based
+        on their RA, and Dec (in radians)
+
+        @param [in] ra is in radians in the International Celestial Reference System.
+        Can be either a float or a numpy array.
+
+        @param [in] dec is in radians in the International Celestial Reference System.
+        Can be either a float or a numpy array.
+
+        @param [in] pm_ra is proper motion in RA multiplied by cos(Dec) (radians/yr)
+        Can be a numpy array or a number or None (default=None).
+
+        @param [in] pm_dec is proper motion in dec (radians/yr)
+        Can be a numpy array or a number or None (default=None).
+
+        @param [in] parallax is parallax in radians
+        Can be a numpy array or a number or None (default=None).
+
+        @param [in] v_rad is radial velocity (km/s)
+        Can be a numpy array or a number or None (default=None).
+
+        @param [in] obs_metadata is an ObservationMetaData characterizing the telescope
+        pointing.
+
+        @param [in] epoch is the epoch in Julian years of the equinox against which
+        RA is measured.  Default is 2000.
+
+        @param [in] chipName designates the names of the chips on which the pixel
+        coordinates will be reckoned.  Can be either single value, an array, or None.
+        If an array, there must be as many chipNames as there are (RA, Dec) pairs.
+        If a single value, all of the pixel coordinates will be reckoned on the same
+        chip.  If None, this method will calculate which chip each(RA, Dec) pair actually
+        falls on, and return pixel coordinates for each (RA, Dec) pair on the appropriate
+        chip.  Default is None.
+
+        @param [in] includeDistortion is a boolean.  If True (default), then this method will
+        return the true pixel coordinates with optical distortion included.  If False, this
+        method will return TAN_PIXEL coordinates, which are the pixel coordinates with
+        estimated optical distortion removed.  See the documentation in afw.cameraGeom for more
+        details.
+
+        @param [out] a 2-D numpy array in which the first row is the x pixel coordinate
+        and the second row is the y pixel coordinate
+        """
+
+        dm_xPix, dm_yPix =  coordUtils._pixelCoordsFromRaDecLSST(ra, dec,
+                                                                 pm_ra=pm_ra, pm_dec=pm_dec,
+                                                                 parallax=parallax, v_rad=v_rad,
+                                                                 obs_metadata=obs_metadata,
+                                                                 chipName=chipName,
+                                                                 epoch=epoch,
+                                                                 includeDistortion=includeDistortion)
+        cam_yPix = dm_xPix
+
+        if isinstance(chipName, list) or isinstance(chipName, np.ndarray):
+            cam_xPix = np.zeros(len(dm_xPix))
+            for ix, (det_name, yy) in enumerate(zip(chipName, dm_yPix)):
+                cam_center_pix = self.getCenterPixel(det_name)
+                cam_xPix[ix] = 2.0*cam_center_pix.getX() - dm_yPix
+        else:
+            cam_center_pix = self.getCenterPixel(chipName)
+            cam_xPix = 2.0*cam_center_pix.getX() - dm_yPix
+
+        return cam_xPix, cam_yPix
+
+    def pixelCoordsFromRaDecLSST(self, ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=None,
+                                 obs_metadata=None, chipName=None,
+                                 epoch=2000.0, includeDistortion=True):
+        """
+        Get the pixel positions on the LSST camera (or nan if not on a chip) for objects based
+        on their RA, and Dec (in degrees)
+
+        @param [in] ra is in degrees in the International Celestial Reference System.
+        Can be either a float or a numpy array.
+
+        @param [in] dec is in degrees in the International Celestial Reference System.
+        Can be either a float or a numpy array.
+
+        @param [in] pm_ra is proper motion in RA multiplied by cos(Dec) (arcsec/yr)
+        Can be a numpy array or a number or None (default=None).
+
+        @param [in] pm_dec is proper motion in dec (arcsec/yr)
+        Can be a numpy array or a number or None (default=None).
+
+        @param [in] parallax is parallax in arcsec
+        Can be a numpy array or a number or None (default=None).
+
+        @param [in] v_rad is radial velocity (km/s)
+        Can be a numpy array or a number or None (default=None).
+
+        @param [in] obs_metadata is an ObservationMetaData characterizing the telescope
+        pointing.
+
+        @param [in] epoch is the epoch in Julian years of the equinox against which
+        RA is measured.  Default is 2000.
+
+        @param [in] chipName designates the names of the chips on which the pixel
+        coordinates will be reckoned.  Can be either single value, an array, or None.
+        If an array, there must be as many chipNames as there are (RA, Dec) pairs.
+        If a single value, all of the pixel coordinates will be reckoned on the same
+        chip.  If None, this method will calculate which chip each(RA, Dec) pair actually
+        falls on, and return pixel coordinates for each (RA, Dec) pair on the appropriate
+        chip.  Default is None.
+
+        @param [in] includeDistortion is a boolean.  If True (default), then this method will
+        return the true pixel coordinates with optical distortion included.  If False, this
+        method will return TAN_PIXEL coordinates, which are the pixel coordinates with
+        estimated optical distortion removed.  See the documentation in afw.cameraGeom for more
+        details.
+
+        @param [out] a 2-D numpy array in which the first row is the x pixel coordinate
+        and the second row is the y pixel coordinate
+        """
+
+        if pm_ra is not None:
+            pm_ra_out = simsUtils.radiansFromArcsec(pm_ra)
+        else:
+            pm_ra_out = None
+
+        if pm_dec is not None:
+            pm_dec_out = simsUtils.radiansFromArcsec(pm_dec)
+        else:
+            pm_dec_out = None
+
+        if parallax is not None:
+            parallax_out = simsUtils.radiansFromArcsec(parallax)
+        else:
+            parallax_out = None
+
+        return self._pixelCoordsFromRaDecLSST(np.radians(ra), np.radians(dec),
+                                              pm_ra=pm_ra_out, pm_dec=pm_dec_out,
+                                              parallax=parallax_out, v_rad=v_rad,
+                                              chipName=chipName, obs_metadata=obs_metadata,
+                                              epoch=2000.0, includeDistortion=includeDistortion)

--- a/python/lsst/sims/GalSimInterface/galSimCameraWrapper.py
+++ b/python/lsst/sims/GalSimInterface/galSimCameraWrapper.py
@@ -96,11 +96,19 @@ class GalSimCameraWrapper(object):
          return self._camera.transform(centerPoint, pixelSystem).getPoint()
 
     def getCenterPupil(self, detector_name):
+        """
+        Return the pupil coordinates of the center of the named detector
+        as an afwGeom.Point2D
+        """
         dd = self._camera[detector_name]
         cs = dd.makeCameraSys(PUPIL)
         return self._camera.transform(dd.getCenter(FOCAL_PLANE), cs).getPoint()
 
     def getCornerPupilList(self, detector_name):
+        """
+        Return a list of the pupil coordinates of the corners of the named
+        detector as a list of afwGeom.Point2D objects
+        """
         dd = self._camera[detector_name]
         pupilSystem = dd.makeCameraSys(PUPIL)
         cornerPointList = dd.getCorners(FOCAL_PLANE)
@@ -112,6 +120,19 @@ class GalSimCameraWrapper(object):
         return pupil_point_list
 
     def getTanPixelBounds(self, detector_name):
+        """
+        Return the min and max pixel values of a detector, assuming
+        all radial distortions are set to zero (i.e. using the afwCameraGeom
+        TAN_PIXELS coordinate system)
+
+        Parameters
+        ----------
+        detector_name is a string denoting the name of the detector
+
+        Returns
+        -------
+        xmin, xmax, ymin, ymax pixel values
+        """
         afwDetector = self._camera[detector_name]
         tanPixelSystem = afwDetector.makeCameraSys(TAN_PIXELS)
         xPixMin = None
@@ -142,13 +163,15 @@ class GalSimCameraWrapper(object):
         Get the pixel positions (or nan if not on a chip) for objects based
         on their pupil coordinates.
 
-        @param [in] xPupil is the x pupil coordinates in radians.
-        Can be either a float or a numpy array.
+        Paramters
+        ---------
+        xPupil is the x pupil coordinates in radians. Can be either a float
+        or a numpy array.
 
-        @param [in] yPupil is the y pupil coordinates in radians.
-        Can be either a float or a numpy array.
+        yPupil is the y pupil coordinates in radians. Can be either a float
+        or a numpy array.
 
-        @param [in] chipName designates the names of the chips on which the pixel
+        chipName designates the names of the chips on which the pixel
         coordinates will be reckoned.  Can be either single value, an array, or None.
         If an array, there must be as many chipNames as there are (RA, Dec) pairs.
         If a single value, all of the pixel coordinates will be reckoned on the same
@@ -156,13 +179,15 @@ class GalSimCameraWrapper(object):
         falls on, and return pixel coordinates for each (RA, Dec) pair on the appropriate
         chip.  Default is None.
 
-        @param [in] includeDistortion is a boolean.  If True (default), then this method will
+        includeDistortion is a boolean.  If True (default), then this method will
         return the true pixel coordinates with optical distortion included.  If False, this
         method will return TAN_PIXEL coordinates, which are the pixel coordinates with
         estimated optical distortion removed.  See the documentation in afw.cameraGeom for more
         details.
 
-        @param [out] a 2-D numpy array in which the first row is the x pixel coordinate
+        Returns
+        -------
+        a 2-D numpy array in which the first row is the x pixel coordinate
         and the second row is the y pixel coordinate
         """
         return coordUtils.pixelCoordsFromPupilCoords(xPupil, yPupil, chipName=chipName,
@@ -174,24 +199,28 @@ class GalSimCameraWrapper(object):
         """
         Convert pixel coordinates into pupil coordinates
 
-        @param [in] xPix is the x pixel coordinate of the point.
+        Parameters
+        ----------
+        xPix is the x pixel coordinate of the point.
         Can be either a float or a numpy array.
 
-        @param [in] yPix is the y pixel coordinate of the point.
+        yPix is the y pixel coordinate of the point.
         Can be either a float or a numpy array.
 
-        @param [in] chipName is the name of the chip(s) on which the pixel coordinates
+        chipName is the name of the chip(s) on which the pixel coordinates
         are defined.  This can be a list (in which case there should be one chip name
         for each (xPix, yPix) coordinate pair), or a single value (in which case, all
         of the (xPix, yPix) points will be reckoned on that chip).
 
-        @param [in] includeDistortion is a boolean.  If True (default), then this method will
+        includeDistortion is a boolean.  If True (default), then this method will
         expect the true pixel coordinates with optical distortion included.  If False, this
         method will expect TAN_PIXEL coordinates, which are the pixel coordinates with
         estimated optical distortion removed.  See the documentation in afw.cameraGeom for more
         details.
 
-        @param [out] a 2-D numpy array in which the first row is the x pupil coordinate
+        Returns
+        -------
+        a 2-D numpy array in which the first row is the x pupil coordinate
         and the second row is the y pupil coordinate (both in radians)
         """
         return coordUtils.pupilCoordsFromPixelCoords(xPix, yPix, chipName,
@@ -203,31 +232,33 @@ class GalSimCameraWrapper(object):
         """
         Convert pixel coordinates into RA, Dec
 
-        @param [in] xPix is the x pixel coordinate.  It can be either
+        Parameters
+        ----------
+        xPix is the x pixel coordinate.  It can be either
         a float or a numpy array.
 
-        @param [in] yPix is the y pixel coordinate.  It can be either
+        yPix is the y pixel coordinate.  It can be either
         a float or a numpy array.
 
-        @param [in] chipName is the name of the chip(s) on which the pixel coordinates
+        chipName is the name of the chip(s) on which the pixel coordinates
         are defined.  This can be a list (in which case there should be one chip name
         for each (xPix, yPix) coordinate pair), or a single value (in which case, all
         of the (xPix, yPix) points will be reckoned on that chip).
 
-        @param [in] camera is an afw.CameraGeom.camera object defining the camera
+        obs_metadata is an ObservationMetaData defining the pointing
 
-        @param [in] obs_metadata is an ObservationMetaData defining the pointing
-
-        @param [in] epoch is the mean epoch in years of the celestial coordinate system.
+        epoch is the mean epoch in years of the celestial coordinate system.
         Default is 2000.
 
-        @param [in] includeDistortion is a boolean.  If True (default), then this method will
+        includeDistortion is a boolean.  If True (default), then this method will
         expect the true pixel coordinates with optical distortion included.  If False, this
         method will expect TAN_PIXEL coordinates, which are the pixel coordinates with
         estimated optical distortion removed.  See the documentation in afw.cameraGeom for more
         details.
 
-        @param [out] a 2-D numpy array in which the first row is the RA coordinate
+        Returns
+        -------
+        a 2-D numpy array in which the first row is the RA coordinate
         and the second row is the Dec coordinate (both in radians; in the
         International Celestial Reference System)
 
@@ -245,6 +276,44 @@ class GalSimCameraWrapper(object):
     def raDecFromPixelCoords(self, xPix, yPix, chipName, obs_metadata,
                              epoch=2000.0, includeDistortion=True):
 
+        """
+        Convert pixel coordinates into RA, Dec
+
+        Parameters
+        ----------
+        xPix is the x pixel coordinate.  It can be either
+        a float or a numpy array.
+
+        yPix is the y pixel coordinate.  It can be either
+        a float or a numpy array.
+
+        chipName is the name of the chip(s) on which the pixel coordinates
+        are defined.  This can be a list (in which case there should be one chip name
+        for each (xPix, yPix) coordinate pair), or a single value (in which case, all
+        of the (xPix, yPix) points will be reckoned on that chip).
+
+        obs_metadata is an ObservationMetaData defining the pointing
+
+        epoch is the mean epoch in years of the celestial coordinate system.
+        Default is 2000.
+
+        includeDistortion is a boolean.  If True (default), then this method will
+        expect the true pixel coordinates with optical distortion included.  If False, this
+        method will expect TAN_PIXEL coordinates, which are the pixel coordinates with
+        estimated optical distortion removed.  See the documentation in afw.cameraGeom for more
+        details.
+
+        Returns
+        -------
+        a 2-D numpy array in which the first row is the RA coordinate
+        and the second row is the Dec coordinate (both in degrees; in the
+        International Celestial Reference System)
+
+        WARNING: This method does not account for apparent motion due to parallax.
+        This method is only useful for mapping positions on a theoretical focal plane
+        to positions on the celestial sphere.
+        """
+
         return coordUtils.raDecFromPixelCoords(xPix, yPix, chipName,
                                                camera=self._camera,
                                                obs_metadata=obs_metadata,
@@ -259,31 +328,33 @@ class GalSimCameraWrapper(object):
         Get the pixel positions (or nan if not on a chip) for objects based
         on their RA, and Dec (in radians)
 
-        @param [in] ra is in radians in the International Celestial Reference System.
+        Parameters
+        ----------
+        ra is in radians in the International Celestial Reference System.
         Can be either a float or a numpy array.
 
-        @param [in] dec is in radians in the International Celestial Reference System.
+        dec is in radians in the International Celestial Reference System.
         Can be either a float or a numpy array.
 
-        @param [in] pm_ra is proper motion in RA multiplied by cos(Dec) (radians/yr)
+        pm_ra is proper motion in RA multiplied by cos(Dec) (radians/yr)
         Can be a numpy array or a number or None (default=None).
 
-        @param [in] pm_dec is proper motion in dec (radians/yr)
+        pm_dec is proper motion in dec (radians/yr)
         Can be a numpy array or a number or None (default=None).
 
-        @param [in] parallax is parallax in radians
+        parallax is parallax in radians
         Can be a numpy array or a number or None (default=None).
 
-        @param [in] v_rad is radial velocity (km/s)
+        v_rad is radial velocity (km/s)
         Can be a numpy array or a number or None (default=None).
 
-        @param [in] obs_metadata is an ObservationMetaData characterizing the telescope
+        obs_metadata is an ObservationMetaData characterizing the telescope
         pointing.
 
-        @param [in] epoch is the epoch in Julian years of the equinox against which
+        epoch is the epoch in Julian years of the equinox against which
         RA is measured.  Default is 2000.
 
-        @param [in] chipName designates the names of the chips on which the pixel
+        chipName designates the names of the chips on which the pixel
         coordinates will be reckoned.  Can be either single value, an array, or None.
         If an array, there must be as many chipNames as there are (RA, Dec) pairs.
         If a single value, all of the pixel coordinates will be reckoned on the same
@@ -291,13 +362,15 @@ class GalSimCameraWrapper(object):
         falls on, and return pixel coordinates for each (RA, Dec) pair on the appropriate
         chip.  Default is None.
 
-        @param [in] includeDistortion is a boolean.  If True (default), then this method will
+        includeDistortion is a boolean.  If True (default), then this method will
         return the true pixel coordinates with optical distortion included.  If False, this
         method will return TAN_PIXEL coordinates, which are the pixel coordinates with
         estimated optical distortion removed.  See the documentation in afw.cameraGeom for more
         details.
 
-        @param [out] a 2-D numpy array in which the first row is the x pixel coordinate
+        Returns
+        -------
+        a 2-D numpy array in which the first row is the x pixel coordinate
         and the second row is the y pixel coordinate
         """
 
@@ -315,31 +388,33 @@ class GalSimCameraWrapper(object):
         Get the pixel positions (or nan if not on a chip) for objects based
         on their RA, and Dec (in degrees)
 
-        @param [in] ra is in degrees in the International Celestial Reference System.
+        Parameters
+        ----------
+        ra is in degrees in the International Celestial Reference System.
         Can be either a float or a numpy array.
 
-        @param [in] dec is in degrees in the International Celestial Reference System.
+        dec is in degrees in the International Celestial Reference System.
         Can be either a float or a numpy array.
 
-        @param [in] pm_ra is proper motion in RA multiplied by cos(Dec) (arcsec/yr)
+        pm_ra is proper motion in RA multiplied by cos(Dec) (arcsec/yr)
         Can be a numpy array or a number or None (default=None).
 
-        @param [in] pm_dec is proper motion in dec (arcsec/yr)
+        pm_dec is proper motion in dec (arcsec/yr)
         Can be a numpy array or a number or None (default=None).
 
-        @param [in] parallax is parallax in arcsec
+        parallax is parallax in arcsec
         Can be a numpy array or a number or None (default=None).
 
-        @param [in] v_rad is radial velocity (km/s)
+        v_rad is radial velocity (km/s)
         Can be a numpy array or a number or None (default=None).
 
-        @param [in] obs_metadata is an ObservationMetaData characterizing the telescope
+        obs_metadata is an ObservationMetaData characterizing the telescope
         pointing.
 
-        @param [in] epoch is the epoch in Julian years of the equinox against which
+        epoch is the epoch in Julian years of the equinox against which
         RA is measured.  Default is 2000.
 
-        @param [in] chipName designates the names of the chips on which the pixel
+        chipName designates the names of the chips on which the pixel
         coordinates will be reckoned.  Can be either single value, an array, or None.
         If an array, there must be as many chipNames as there are (RA, Dec) pairs.
         If a single value, all of the pixel coordinates will be reckoned on the same
@@ -347,13 +422,15 @@ class GalSimCameraWrapper(object):
         falls on, and return pixel coordinates for each (RA, Dec) pair on the appropriate
         chip.  Default is None.
 
-        @param [in] includeDistortion is a boolean.  If True (default), then this method will
+        includeDistortion is a boolean.  If True (default), then this method will
         return the true pixel coordinates with optical distortion included.  If False, this
         method will return TAN_PIXEL coordinates, which are the pixel coordinates with
         estimated optical distortion removed.  See the documentation in afw.cameraGeom for more
         details.
 
-        @param [out] a 2-D numpy array in which the first row is the x pixel coordinate
+        Returns
+        -------
+        a 2-D numpy array in which the first row is the x pixel coordinate
         and the second row is the y pixel coordinate
         """
 
@@ -392,6 +469,19 @@ class LSSTCameraWrapper(GalSimCameraWrapper):
          return afwGeom.coordinates.Point2D(centerPixel.getY(), centerPixel.getX())
 
     def getTanPixelBounds(self, detector_name):
+        """
+        Return the min and max pixel values of a detector, assuming
+        all radial distortions are set to zero (i.e. using the afwCameraGeom
+        TAN_PIXELS coordinate system)
+
+        Parameters
+        ----------
+        detector_name is a string denoting the name of the detector
+
+        Returns
+        -------
+        xmin, xmax, ymin, ymax pixel values
+        """
         dm_xmin, dm_xmax, dm_ymin, dm_ymax = GalSimCameraWrapper.getTanPixelBounds(self, detector_name)
         return dm_ymin, dm_ymax, dm_xmin, dm_xmax
 
@@ -401,13 +491,15 @@ class LSSTCameraWrapper(GalSimCameraWrapper):
         Get the pixel positions (or nan if not on a chip) for objects based
         on their pupil coordinates.
 
-        @param [in] xPupil is the x pupil coordinates in radians.
-        Can be either a float or a numpy array.
+        Paramters
+        ---------
+        xPupil is the x pupil coordinates in radians. Can be either a float
+        or a numpy array.
 
-        @param [in] yPupil is the y pupil coordinates in radians.
-        Can be either a float or a numpy array.
+        yPupil is the y pupil coordinates in radians. Can be either a float
+        or a numpy array.
 
-        @param [in] chipName designates the names of the chips on which the pixel
+        chipName designates the names of the chips on which the pixel
         coordinates will be reckoned.  Can be either single value, an array, or None.
         If an array, there must be as many chipNames as there are (RA, Dec) pairs.
         If a single value, all of the pixel coordinates will be reckoned on the same
@@ -415,13 +507,15 @@ class LSSTCameraWrapper(GalSimCameraWrapper):
         falls on, and return pixel coordinates for each (RA, Dec) pair on the appropriate
         chip.  Default is None.
 
-        @param [in] includeDistortion is a boolean.  If True (default), then this method will
+        includeDistortion is a boolean.  If True (default), then this method will
         return the true pixel coordinates with optical distortion included.  If False, this
         method will return TAN_PIXEL coordinates, which are the pixel coordinates with
         estimated optical distortion removed.  See the documentation in afw.cameraGeom for more
         details.
 
-        @param [out] a 2-D numpy array in which the first row is the x pixel coordinate
+        Returns
+        -------
+        a 2-D numpy array in which the first row is the x pixel coordinate
         and the second row is the y pixel coordinate
         """
         dm_x_pix, dm_y_pix = coordUtils.pixelCoordsFromPupilCoords(xPupil, yPupil,
@@ -442,28 +536,31 @@ class LSSTCameraWrapper(GalSimCameraWrapper):
         return cam_x_pix, cam_y_pix
 
     def pupilCoordsFromPixelCoords(self, xPix, yPix, chipName, includeDistortion=True):
-
         """
         Convert pixel coordinates into pupil coordinates
 
-        @param [in] xPix is the x pixel coordinate of the point.
+        Parameters
+        ----------
+        xPix is the x pixel coordinate of the point.
         Can be either a float or a numpy array.
 
-        @param [in] yPix is the y pixel coordinate of the point.
+        yPix is the y pixel coordinate of the point.
         Can be either a float or a numpy array.
 
-        @param [in] chipName is the name of the chip(s) on which the pixel coordinates
+        chipName is the name of the chip(s) on which the pixel coordinates
         are defined.  This can be a list (in which case there should be one chip name
         for each (xPix, yPix) coordinate pair), or a single value (in which case, all
         of the (xPix, yPix) points will be reckoned on that chip).
 
-        @param [in] includeDistortion is a boolean.  If True (default), then this method will
+        includeDistortion is a boolean.  If True (default), then this method will
         expect the true pixel coordinates with optical distortion included.  If False, this
         method will expect TAN_PIXEL coordinates, which are the pixel coordinates with
         estimated optical distortion removed.  See the documentation in afw.cameraGeom for more
         details.
 
-        @param [out] a 2-D numpy array in which the first row is the x pupil coordinate
+        Returns
+        -------
+        a 2-D numpy array in which the first row is the x pupil coordinate
         and the second row is the y pupil coordinate (both in radians)
         """
         dm_xPix = yPix
@@ -484,31 +581,33 @@ class LSSTCameraWrapper(GalSimCameraWrapper):
         """
         Convert pixel coordinates into RA, Dec
 
-        @param [in] xPix is the x pixel coordinate.  It can be either
+        Parameters
+        ----------
+        xPix is the x pixel coordinate.  It can be either
         a float or a numpy array.
 
-        @param [in] yPix is the y pixel coordinate.  It can be either
+        yPix is the y pixel coordinate.  It can be either
         a float or a numpy array.
 
-        @param [in] chipName is the name of the chip(s) on which the pixel coordinates
+        chipName is the name of the chip(s) on which the pixel coordinates
         are defined.  This can be a list (in which case there should be one chip name
         for each (xPix, yPix) coordinate pair), or a single value (in which case, all
         of the (xPix, yPix) points will be reckoned on that chip).
 
-        @param [in] camera is an afw.CameraGeom.camera object defining the camera
+        obs_metadata is an ObservationMetaData defining the pointing
 
-        @param [in] obs_metadata is an ObservationMetaData defining the pointing
-
-        @param [in] epoch is the mean epoch in years of the celestial coordinate system.
+        epoch is the mean epoch in years of the celestial coordinate system.
         Default is 2000.
 
-        @param [in] includeDistortion is a boolean.  If True (default), then this method will
+        includeDistortion is a boolean.  If True (default), then this method will
         expect the true pixel coordinates with optical distortion included.  If False, this
         method will expect TAN_PIXEL coordinates, which are the pixel coordinates with
         estimated optical distortion removed.  See the documentation in afw.cameraGeom for more
         details.
 
-        @param [out] a 2-D numpy array in which the first row is the RA coordinate
+        Returns
+        -------
+        a 2-D numpy array in which the first row is the RA coordinate
         and the second row is the Dec coordinate (both in radians; in the
         International Celestial Reference System)
 
@@ -539,31 +638,33 @@ class LSSTCameraWrapper(GalSimCameraWrapper):
         """
         Convert pixel coordinates into RA, Dec
 
-        @param [in] xPix is the x pixel coordinate.  It can be either
+        Parameters
+        ----------
+        xPix is the x pixel coordinate.  It can be either
         a float or a numpy array.
 
-        @param [in] yPix is the y pixel coordinate.  It can be either
+        yPix is the y pixel coordinate.  It can be either
         a float or a numpy array.
 
-        @param [in] chipName is the name of the chip(s) on which the pixel coordinates
+        chipName is the name of the chip(s) on which the pixel coordinates
         are defined.  This can be a list (in which case there should be one chip name
         for each (xPix, yPix) coordinate pair), or a single value (in which case, all
         of the (xPix, yPix) points will be reckoned on that chip).
 
-        @param [in] camera is an afw.CameraGeom.camera object defining the camera
+        obs_metadata is an ObservationMetaData defining the pointing
 
-        @param [in] obs_metadata is an ObservationMetaData defining the pointing
-
-        @param [in] epoch is the mean epoch in years of the celestial coordinate system.
+        epoch is the mean epoch in years of the celestial coordinate system.
         Default is 2000.
 
-        @param [in] includeDistortion is a boolean.  If True (default), then this method will
+        includeDistortion is a boolean.  If True (default), then this method will
         expect the true pixel coordinates with optical distortion included.  If False, this
         method will expect TAN_PIXEL coordinates, which are the pixel coordinates with
         estimated optical distortion removed.  See the documentation in afw.cameraGeom for more
         details.
 
-        @param [out] a 2-D numpy array in which the first row is the RA coordinate
+        Returns
+        -------
+        a 2-D numpy array in which the first row is the RA coordinate
         and the second row is the Dec coordinate (both in degrees; in the
         International Celestial Reference System)
 
@@ -586,31 +687,33 @@ class LSSTCameraWrapper(GalSimCameraWrapper):
         Get the pixel positions (or nan if not on a chip) for objects based
         on their RA, and Dec (in radians)
 
-        @param [in] ra is in radians in the International Celestial Reference System.
+        Parameters
+        ----------
+        ra is in radians in the International Celestial Reference System.
         Can be either a float or a numpy array.
 
-        @param [in] dec is in radians in the International Celestial Reference System.
+        dec is in radians in the International Celestial Reference System.
         Can be either a float or a numpy array.
 
-        @param [in] pm_ra is proper motion in RA multiplied by cos(Dec) (radians/yr)
+        pm_ra is proper motion in RA multiplied by cos(Dec) (radians/yr)
         Can be a numpy array or a number or None (default=None).
 
-        @param [in] pm_dec is proper motion in dec (radians/yr)
+        pm_dec is proper motion in dec (radians/yr)
         Can be a numpy array or a number or None (default=None).
 
-        @param [in] parallax is parallax in radians
+        parallax is parallax in radians
         Can be a numpy array or a number or None (default=None).
 
-        @param [in] v_rad is radial velocity (km/s)
+        v_rad is radial velocity (km/s)
         Can be a numpy array or a number or None (default=None).
 
-        @param [in] obs_metadata is an ObservationMetaData characterizing the telescope
+        obs_metadata is an ObservationMetaData characterizing the telescope
         pointing.
 
-        @param [in] epoch is the epoch in Julian years of the equinox against which
+        epoch is the epoch in Julian years of the equinox against which
         RA is measured.  Default is 2000.
 
-        @param [in] chipName designates the names of the chips on which the pixel
+        chipName designates the names of the chips on which the pixel
         coordinates will be reckoned.  Can be either single value, an array, or None.
         If an array, there must be as many chipNames as there are (RA, Dec) pairs.
         If a single value, all of the pixel coordinates will be reckoned on the same
@@ -618,13 +721,15 @@ class LSSTCameraWrapper(GalSimCameraWrapper):
         falls on, and return pixel coordinates for each (RA, Dec) pair on the appropriate
         chip.  Default is None.
 
-        @param [in] includeDistortion is a boolean.  If True (default), then this method will
+        includeDistortion is a boolean.  If True (default), then this method will
         return the true pixel coordinates with optical distortion included.  If False, this
         method will return TAN_PIXEL coordinates, which are the pixel coordinates with
         estimated optical distortion removed.  See the documentation in afw.cameraGeom for more
         details.
 
-        @param [out] a 2-D numpy array in which the first row is the x pixel coordinate
+        Returns
+        -------
+        a 2-D numpy array in which the first row is the x pixel coordinate
         and the second row is the y pixel coordinate
         """
 
@@ -652,34 +757,36 @@ class LSSTCameraWrapper(GalSimCameraWrapper):
                                  obs_metadata=None, chipName=None,
                                  epoch=2000.0, includeDistortion=True):
         """
-        Get the pixel positions on the LSST camera (or nan if not on a chip) for objects based
+        Get the pixel positions (or nan if not on a chip) for objects based
         on their RA, and Dec (in degrees)
 
-        @param [in] ra is in degrees in the International Celestial Reference System.
+        Parameters
+        ----------
+        ra is in degrees in the International Celestial Reference System.
         Can be either a float or a numpy array.
 
-        @param [in] dec is in degrees in the International Celestial Reference System.
+        dec is in degrees in the International Celestial Reference System.
         Can be either a float or a numpy array.
 
-        @param [in] pm_ra is proper motion in RA multiplied by cos(Dec) (arcsec/yr)
+        pm_ra is proper motion in RA multiplied by cos(Dec) (arcsec/yr)
         Can be a numpy array or a number or None (default=None).
 
-        @param [in] pm_dec is proper motion in dec (arcsec/yr)
+        pm_dec is proper motion in dec (arcsec/yr)
         Can be a numpy array or a number or None (default=None).
 
-        @param [in] parallax is parallax in arcsec
+        parallax is parallax in arcsec
         Can be a numpy array or a number or None (default=None).
 
-        @param [in] v_rad is radial velocity (km/s)
+        v_rad is radial velocity (km/s)
         Can be a numpy array or a number or None (default=None).
 
-        @param [in] obs_metadata is an ObservationMetaData characterizing the telescope
+        obs_metadata is an ObservationMetaData characterizing the telescope
         pointing.
 
-        @param [in] epoch is the epoch in Julian years of the equinox against which
+        epoch is the epoch in Julian years of the equinox against which
         RA is measured.  Default is 2000.
 
-        @param [in] chipName designates the names of the chips on which the pixel
+        chipName designates the names of the chips on which the pixel
         coordinates will be reckoned.  Can be either single value, an array, or None.
         If an array, there must be as many chipNames as there are (RA, Dec) pairs.
         If a single value, all of the pixel coordinates will be reckoned on the same
@@ -687,13 +794,15 @@ class LSSTCameraWrapper(GalSimCameraWrapper):
         falls on, and return pixel coordinates for each (RA, Dec) pair on the appropriate
         chip.  Default is None.
 
-        @param [in] includeDistortion is a boolean.  If True (default), then this method will
+        includeDistortion is a boolean.  If True (default), then this method will
         return the true pixel coordinates with optical distortion included.  If False, this
         method will return TAN_PIXEL coordinates, which are the pixel coordinates with
         estimated optical distortion removed.  See the documentation in afw.cameraGeom for more
         details.
 
-        @param [out] a 2-D numpy array in which the first row is the x pixel coordinate
+        Returns
+        -------
+        a 2-D numpy array in which the first row is the x pixel coordinate
         and the second row is the y pixel coordinate
         """
 

--- a/python/lsst/sims/GalSimInterface/galSimCameraWrapper.py
+++ b/python/lsst/sims/GalSimInterface/galSimCameraWrapper.py
@@ -753,9 +753,9 @@ class LSSTCameraWrapper(GalSimCameraWrapper):
 
         return cam_xPix, cam_yPix
 
-    def pixelCoordsFromRaDecLSST(self, ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=None,
-                                 obs_metadata=None, chipName=None,
-                                 epoch=2000.0, includeDistortion=True):
+    def pixelCoordsFromRaDec(self, ra, dec, pm_ra=None, pm_dec=None, parallax=None, v_rad=None,
+                             obs_metadata=None, chipName=None,
+                             epoch=2000.0, includeDistortion=True):
         """
         Get the pixel positions (or nan if not on a chip) for objects based
         on their RA, and Dec (in degrees)
@@ -821,8 +821,8 @@ class LSSTCameraWrapper(GalSimCameraWrapper):
         else:
             parallax_out = None
 
-        return self._pixelCoordsFromRaDecLSST(np.radians(ra), np.radians(dec),
-                                              pm_ra=pm_ra_out, pm_dec=pm_dec_out,
-                                              parallax=parallax_out, v_rad=v_rad,
-                                              chipName=chipName, obs_metadata=obs_metadata,
-                                              epoch=2000.0, includeDistortion=includeDistortion)
+        return self._pixelCoordsFromRaDec(np.radians(ra), np.radians(dec),
+                                          pm_ra=pm_ra_out, pm_dec=pm_dec_out,
+                                          parallax=parallax_out, v_rad=v_rad,
+                                          chipName=chipName, obs_metadata=obs_metadata,
+                                          epoch=2000.0, includeDistortion=includeDistortion)

--- a/python/lsst/sims/GalSimInterface/galSimCameraWrapper.py
+++ b/python/lsst/sims/GalSimInterface/galSimCameraWrapper.py
@@ -204,7 +204,9 @@ class GalSimCameraWrapper(object):
     def raDecFromPixelCoords(self, xPix, yPix, chipName, obs_metadata,
                              epoch=2000.0, includeDistortion=True):
 
-        return coordUtils.raDecFromPixelCoords(xPix, yPix, chipName, obs_metadata,
+        return coordUtils.raDecFromPixelCoords(xPix, yPix, chipName,
+                                               camera=self._camera,
+                                               obs_metadata=obs_metadata,
                                                epoch=2000.0, includeDistortion=True)
 
     def _pixelCoordsFromRaDec(self, ra, dec, pm_ra=None, pm_dec=None,
@@ -529,7 +531,8 @@ class LSSTCameraWrapper(GalSimCameraWrapper):
         to positions on the celestial sphere.
         """
 
-        _ra, _dec = self._raDecFromPixelCoords(xPix, yPix, chipName, obs_metadata,
+        _ra, _dec = self._raDecFromPixelCoords(xPix, yPix, chipName,
+                                               obs_metadata=obs_metadata,
                                                epoch=2000.0, includeDistortion=True)
 
         return np.degrees(_ra), np.degrees(_dec)

--- a/python/lsst/sims/GalSimInterface/galSimCameraWrapper.py
+++ b/python/lsst/sims/GalSimInterface/galSimCameraWrapper.py
@@ -1,8 +1,9 @@
 """
 This module provides wrappers for afwCameraGeom camera objects.
-This is necessary because of the 90-degree rotation between
-how DM defines pixel coordinates and how the Camera team (and
-thus PhoSim) defines pixel coordinates.  Recall
+This is necessary because of a 90-degree rotation between how
+the LSST Data Management software team defines coordinate
+axes on the focal plane and how the LSST Camera team defines
+coorindate axes on the focal plane.  Specifically
 
 Camera +y = DM +x
 Camera +x = DM -y
@@ -12,6 +13,46 @@ as PhoSim e-images, we need to apply this rotation to the
 mappings between RA, Dec and pixel coordinates.  We may not
 wish to do that for arbitrary cameras, so we will give
 users the ability to apply a no-op wrapper to their cameras.
+
+The class LSSTCameraWrapper applies this transformation.
+In cases where users do not wish to apply any transformation
+to their pixel coordinate system, the class GalSimCameraWrapper
+provides the same API as LSSTCamerWrapper, but treats the
+software-based pixel coordinates as truth.
+
+In order to implement your own camera wrapper, create a python
+class that inherits from GalSimCameraWrapper.  This class will
+need:
+
+- a property self.camera that is an afwCamerGeom camera object
+
+- a method getBBox() that returns the bounding box in pixel space
+  of a detector, given that detector's name
+
+- a method getCenterPixel() that returns the central pixel of a
+  detector, given that detector's name
+
+- a method getCenterPupil() that returns the pupil coordinates
+  (or field angle) in radians of the center of a detector given
+  that detector's name
+
+- a method getCornerPupilList that returns the pupil coordinates
+  (or field angles) in radians of the corners of a detector given
+  that detector's name
+
+- a method getTanPixelBounds() that returns the minimum and maximum
+  x and y pixel values of a detector, ignoring radial distortions,
+  given that detector's name
+
+- wrappers to the corresponding methods in lsst.sims.coordUtils that
+  use the self.camera property and apply the necessary transformations
+  to pixel space coordinates:
+      pixelCoordsFromPupilCoords()
+      pupilCoordsFromPixelCoords()
+      pixelCoordsFromRaDec()
+      _pixelCoordsFromRaDec()
+      raDecFromPixelCoords()
+      _raDecFromPixelCoords()
 """
 
 import numpy as np

--- a/python/lsst/sims/GalSimInterface/galSimCameraWrapper.py
+++ b/python/lsst/sims/GalSimInterface/galSimCameraWrapper.py
@@ -516,7 +516,8 @@ class LSSTCameraWrapper(GalSimCameraWrapper):
         Returns
         -------
         a 2-D numpy array in which the first row is the x pixel coordinate
-        and the second row is the y pixel coordinate
+        and the second row is the y pixel coordinate.  These pixel coordinates
+        are defined in the Camera team system, rather than the DM system.
         """
         dm_x_pix, dm_y_pix = coordUtils.pixelCoordsFromPupilCoords(xPupil, yPupil,
                                                                    chipName=chipName,
@@ -543,9 +544,11 @@ class LSSTCameraWrapper(GalSimCameraWrapper):
         ----------
         xPix is the x pixel coordinate of the point.
         Can be either a float or a numpy array.
+        Defined in the Camera team system (not the DM system).
 
         yPix is the y pixel coordinate of the point.
         Can be either a float or a numpy array.
+        Defined in the Camera team system (not the DM system).
 
         chipName is the name of the chip(s) on which the pixel coordinates
         are defined.  This can be a list (in which case there should be one chip name
@@ -584,10 +587,12 @@ class LSSTCameraWrapper(GalSimCameraWrapper):
         Parameters
         ----------
         xPix is the x pixel coordinate.  It can be either
-        a float or a numpy array.
+        a float or a numpy array.  Defined in the Camera
+        team system (not the DM system).
 
         yPix is the y pixel coordinate.  It can be either
-        a float or a numpy array.
+        a float or a numpy array.  Defined in the Camera
+        team system (not the DM system).
 
         chipName is the name of the chip(s) on which the pixel coordinates
         are defined.  This can be a list (in which case there should be one chip name
@@ -641,10 +646,12 @@ class LSSTCameraWrapper(GalSimCameraWrapper):
         Parameters
         ----------
         xPix is the x pixel coordinate.  It can be either
-        a float or a numpy array.
+        a float or a numpy array.  Defined in the Camera
+        team system (not the DM system).
 
         yPix is the y pixel coordinate.  It can be either
-        a float or a numpy array.
+        a float or a numpy array.  Defined in the Camera
+        team system (not the DM system).
 
         chipName is the name of the chip(s) on which the pixel coordinates
         are defined.  This can be a list (in which case there should be one chip name
@@ -730,7 +737,8 @@ class LSSTCameraWrapper(GalSimCameraWrapper):
         Returns
         -------
         a 2-D numpy array in which the first row is the x pixel coordinate
-        and the second row is the y pixel coordinate
+        and the second row is the y pixel coordinate.  These pixel coordinates
+        are defined in the Camera team system, rather than the DM system.
         """
 
         dm_xPix, dm_yPix =  coordUtils._pixelCoordsFromRaDecLSST(ra, dec,
@@ -803,7 +811,8 @@ class LSSTCameraWrapper(GalSimCameraWrapper):
         Returns
         -------
         a 2-D numpy array in which the first row is the x pixel coordinate
-        and the second row is the y pixel coordinate
+        and the second row is the y pixel coordinate.  These pixel coordinates
+        are defined in the Camera team system, rather than the DM system.
         """
 
         if pm_ra is not None:

--- a/python/lsst/sims/GalSimInterface/galSimCameraWrapper.py
+++ b/python/lsst/sims/GalSimInterface/galSimCameraWrapper.py
@@ -57,7 +57,7 @@ need:
 
 import numpy as np
 from lsst.afw.cameraGeom import FOCAL_PLANE, PIXELS, TAN_PIXELS
-from lsst.afw.cameraGeom import PUPIL
+from lsst.afw.cameraGeom import FIELD_ANGLE
 import lsst.afw.geom as afwGeom
 import lsst.sims.coordUtils as coordUtils
 import lsst.sims.utils as simsUtils
@@ -101,7 +101,7 @@ class GalSimCameraWrapper(object):
         as an afwGeom.Point2D
         """
         dd = self._camera[detector_name]
-        cs = dd.makeCameraSys(PUPIL)
+        cs = dd.makeCameraSys(FIELD_ANGLE)
         return self._camera.transform(dd.getCenter(FOCAL_PLANE), cs).getPoint()
 
     def getCornerPupilList(self, detector_name):
@@ -110,7 +110,7 @@ class GalSimCameraWrapper(object):
         detector as a list of afwGeom.Point2D objects
         """
         dd = self._camera[detector_name]
-        pupilSystem = dd.makeCameraSys(PUPIL)
+        pupilSystem = dd.makeCameraSys(FIELD_ANGLE)
         cornerPointList = dd.getCorners(FOCAL_PLANE)
         pupil_point_list = []
         for cornerPoint in cornerPointList:

--- a/python/lsst/sims/GalSimInterface/galSimCatalogs.py
+++ b/python/lsst/sims/GalSimInterface/galSimCatalogs.py
@@ -567,7 +567,7 @@ class GalSimGalaxies(GalSimBase, AstrometryGalaxies, EBVmixin):
     galsim_type = 'sersic'
     default_columns = [('galacticAv', 0.1, float),
                        ('galacticRv', 3.1, float),
-                       ('galSimType', 'sersic', (str, 6))]
+                       ('galSimType', 'sersic', str, 6)]
 
 
 class GalSimAgn(GalSimBase, AstrometryGalaxies, EBVmixin):
@@ -580,7 +580,7 @@ class GalSimAgn(GalSimBase, AstrometryGalaxies, EBVmixin):
     galsim_type = 'pointSource'
     default_columns = [('galacticAv', 0.1, float),
                        ('galacticRv', 3.1, float),
-                       ('galSimType', 'pointSource', (str, 11)),
+                       ('galSimType', 'pointSource', str, 11),
                        ('majorAxis', 0.0, float),
                        ('minorAxis', 0.0, float),
                        ('sindex', 0.0, float),
@@ -600,7 +600,7 @@ class GalSimStars(GalSimBase, AstrometryStars, EBVmixin):
     galsim_type = 'pointSource'
     default_columns = [('galacticAv', 0.1, float),
                        ('galacticRv', 3.1, float),
-                       ('galSimType', 'pointSource', (str, 11)),
+                       ('galSimType', 'pointSource', str, 11),
                        ('internalAv', 0.0, float),
                        ('internalRv', 0.0, float),
                        ('redshift', 0.0, float),

--- a/python/lsst/sims/GalSimInterface/galSimCatalogs.py
+++ b/python/lsst/sims/GalSimInterface/galSimCatalogs.py
@@ -28,6 +28,7 @@ from lsst.sims.photUtils import (Sed, Bandpass, BandpassDict,
 import lsst.afw.cameraGeom.testUtils as camTestUtils
 import lsst.afw.geom as afwGeom
 from lsst.afw.cameraGeom import FIELD_ANGLE, PIXELS, FOCAL_PLANE
+from lsst.afw.cameraGeom import WAVEFRONT, GUIDER
 
 __all__ = ["GalSimGalaxies", "GalSimAgn", "GalSimStars"]
 
@@ -439,6 +440,11 @@ class GalSimBase(InstanceCatalog, CameraCoords):
             detectors = []
 
             for dd in self.camera:
+                if dd.getType() == WAVEFRONT or dd.getType() == GUIDER:
+                    # This package does not yet handle the 90-degree rotation
+                    # in WCS that occurs for wavefront or guide sensors
+                    continue
+
                 if self.allowed_chips is None or dd.getName() in self.allowed_chips:
                     cs = dd.makeCameraSys(FIELD_ANGLE)
                     centerPupil = self.camera.transform(dd.getCenter(FOCAL_PLANE), cs).getPoint()

--- a/python/lsst/sims/GalSimInterface/galSimCatalogs.py
+++ b/python/lsst/sims/GalSimInterface/galSimCatalogs.py
@@ -426,10 +426,11 @@ class GalSimBase(InstanceCatalog, CameraCoords):
         """
         self.camera_wrapper = otherCatalog.camera_wrapper
         self.photParams = otherCatalog.photParams
-        self.bandpassDict = otherCatalog.bandpassDict
-        self.galSimInterpreter = otherCatalog.galSimInterpreter
         self.PSF = otherCatalog.PSF
         self.noise_and_background = otherCatalog.noise_and_background
+        if otherCatalog.hasBeenInitialized:
+            self.bandpassDict = otherCatalog.bandpassDict
+            self.galSimInterpreter = otherCatalog.galSimInterpreter
 
     def _initializeGalSimInterpreter(self):
         """

--- a/python/lsst/sims/GalSimInterface/galSimCatalogs.py
+++ b/python/lsst/sims/GalSimInterface/galSimCatalogs.py
@@ -191,7 +191,7 @@ class GalSimBase(InstanceCatalog, CameraCoords):
 
     # This must be an instantiation of the GalSimCameraWrapper class defined in
     # galSimCameraWrapper.py
-    camera_wrapper = None
+    _camera_wrapper = None
 
     uniqueSeds = {}  # a cache for un-normalized SED files, so that we do not waste time on I/O
 
@@ -201,6 +201,15 @@ class GalSimBase(InstanceCatalog, CameraCoords):
 
     totalDrawings = 0
     totalObjects = 0
+
+    @property
+    def camera_wrapper(self):
+        return self._camera_wrapper
+
+    @camera_wrapper.setter
+    def camera_wrapper(self, val):
+        self._camera_wrapper = val
+        self.camera = val.camera
 
     def _initializeGalSimCatalog(self):
         """

--- a/python/lsst/sims/GalSimInterface/galSimDetector.py
+++ b/python/lsst/sims/GalSimInterface/galSimDetector.py
@@ -7,10 +7,8 @@ import lsst.afw.geom as afwGeom
 from lsst.afw.cameraGeom import FIELD_ANGLE, PIXELS, FOCAL_PLANE
 from lsst.afw.cameraGeom import WAVEFRONT, GUIDER
 from lsst.sims.utils import arcsecFromRadians
-from lsst.sims.coordUtils import (_raDecFromPixelCoords,
-                                  _pixelCoordsFromRaDec,
-                                  pixelCoordsFromPupilCoords)
 from lsst.sims.GalSimInterface.wcsUtils import tanSipWcsFromDetector
+from lsst.sims.GalSimInterface import GalSimCameraWrapper
 
 __all__ = ["GalSimDetector"]
 
@@ -27,11 +25,12 @@ class GalSim_afw_TanSipWCS(galsim.wcs.CelestialWCS):
     http://fits.gsfc.nasa.gov/registry/sip/SIP_distortion_v1_0.pdf
     """
 
-    def __init__(self, afwDetector, afwCamera, obs_metadata, epoch, photParams=None, wcs=None):
+    def __init__(self, detectorName, cameraWrapper, obs_metadata, epoch, photParams=None, wcs=None):
         """
-        @param [in] afwDetector is an instantiation of afw.cameraGeom.Detector
+        @param [in] detectorName is the name of the detector as stored
+        by afw
 
-        @param [in] afwCamera is an instantiation of afw.cameraGeom.Camera
+        @param [in] cameraWrapper is an instantionat of a GalSimCameraWrapper
 
         @param [in] obs_metadata is an instantiation of ObservationMetaData
         characterizing the telescope pointing
@@ -46,13 +45,18 @@ class GalSim_afw_TanSipWCS(galsim.wcs.CelestialWCS):
         The wcs kwarg in this constructor method should not be used by users.
         """
 
+        if not isinstance(cameraWrapper, GalSimCameraWrapper):
+            raise RuntimeError("You must pass GalSim_afw_TanSipWCS an instantiation "
+                               "of GalSimCameraWrapper or one of its daughter "
+                               "classes")
+
         if wcs is None:
-            self._tanSipWcs = tanSipWcsFromDetector(afwDetector, afwCamera, obs_metadata, epoch)
+            self._tanSipWcs = tanSipWcsFromDetector(detectorName, cameraWrapper, obs_metadata, epoch)
         else:
             self._tanSipWcs = wcs
 
-        self.afwDetector = afwDetector
-        self.afwCamera = afwCamera
+        self.detectorName = detectorName
+        self.cameraWrapper = cameraWrapper
         self.obs_metadata = obs_metadata
         self.photParams = photParams
         self.epoch = epoch
@@ -92,15 +96,14 @@ class GalSim_afw_TanSipWCS(galsim.wcs.CelestialWCS):
         Return ra, dec in radians.
         """
 
-        chipNameList = [self.afwDetector.getName()]
+        chipNameList = [self.detectorName]
 
         if type(x) is np.ndarray:
             chipNameList = chipNameList * len(x)
 
-        ra, dec = _raDecFromPixelCoords(x + self.afw_crpix1, y + self.afw_crpix2, chipNameList,
-                                        camera=self.afwCamera,
-                                        obs_metadata=self.obs_metadata,
-                                        epoch=self.epoch)
+        ra, dec = self.cameraWrapper._raDecFromPixelCoords(x + self.afw_crpix1, y + self.afw_crpix2, chipNameList,
+                                                           obs_metadata=self.obs_metadata,
+                                                           epoch=self.epoch)
 
         if type(x) is np.ndarray:
             return (ra, dec)
@@ -114,15 +117,14 @@ class GalSim_afw_TanSipWCS(galsim.wcs.CelestialWCS):
         Convert ra, dec in radians into x, y in pixel space with crpix subtracted.
         """
 
-        chipNameList = [self.afwDetector.getName()]
+        chipNameList = [self.detectorName]
 
         if type(ra) is np.ndarray:
             chipNameList = chipNameList * len(ra)
 
-        xx, yy = _pixelCoordsFromRaDec(ra=ra, dec=dec, chipName=chipNameList,
-                                       obs_metadata=self.obs_metadata,
-                                       epoch=self.epoch,
-                                       camera = self.afwCamera)
+        xx, yy = self.cameraWrapper._pixelCoordsFromRaDec(ra=ra, dec=dec, chipName=chipNameList,
+                                                          obs_metadata=self.obs_metadata,
+                                                          epoch=self.epoch)
 
         if type(ra) is np.ndarray:
             return (xx-self.crpix1, yy-self.crpix2)
@@ -141,7 +143,7 @@ class GalSim_afw_TanSipWCS(galsim.wcs.CelestialWCS):
         @param [out] _newWcs is a WCS identical to self, but with the origin
         in pixel space moved to the specified origin
         """
-        _newWcs = GalSim_afw_TanSipWCS(self.afwDetector, self.afwCamera, self.obs_metadata, self.epoch,
+        _newWcs = GalSim_afw_TanSipWCS(self.detectorName, self.cameraWrapper, self.obs_metadata, self.epoch,
                                        photParams=self.photParams, wcs=self._tanSipWcs)
         _newWcs.crpix1 = origin.x
         _newWcs.crpix2 = origin.y
@@ -161,11 +163,12 @@ class GalSimDetector(object):
     This class stores information about individual detectors for use by the GalSimInterpreter
     """
 
-    def __init__(self, afwDetector, afwCamera, obs_metadata, epoch, photParams=None):
+    def __init__(self, detectorName, cameraWrapper, obs_metadata, epoch, photParams=None):
         """
-        @param [in] afwDetector is an instaniation of afw.cameraGeom.Detector
+        @param [in] detectorName is the name of the detector as stored
+        by afw
 
-        @param [in] afwCamera is an instantiation of afw.cameraGeom.camera
+        @param [in] cameraWrapper is an instantionat of a GalSimCameraWrapper
 
         @param [in] photParams is an instantiation of the PhotometricParameters class that carries
         details about the photometric response of the telescope.
@@ -174,50 +177,47 @@ class GalSimDetector(object):
         the name of the detector as it will appear in the output FITS files
         """
 
+        if not isinstance(cameraWrapper, GalSimCameraWrapper):
+            raise RuntimeError("You must pass GalSimDetector an instantiation "
+                               "of GalSimCameraWrapper or one of its daughter "
+                               "classes")
+
         if photParams is None:
             raise RuntimeError("You need to specify an instantiation of PhotometricParameters " +
                                "when constructing a GalSimDetector")
 
         self._wcs = None  # this will be created when it is actually called for
-        self._name = afwDetector.getName()
-        self._afwDetector = afwDetector
-        self._afwCamera = afwCamera
+        self._name = detectorName
+        self._cameraWrapper = cameraWrapper
         self._obs_metadata = obs_metadata
         self._epoch = epoch
+        self._detector_type = self._cameraWrapper.camera[self._name].getType()
 
         # We are transposing the coordinates because of the difference
         # between how DM defines pixel coordinates and how the
         # Camera team defines pixel coordinates
-        bbox = afwDetector.getBBox()
-        self._xMinPix = bbox.getMinY()
-        self._xMaxPix = bbox.getMaxY()
-        self._yMinPix = bbox.getMinX()
-        self._yMaxPix = bbox.getMaxX()
+        bbox = self._cameraWrapper.getBBox(self._name)
+        self._xMinPix = bbox.getMinX()
+        self._xMaxPix = bbox.getMaxX()
+        self._yMinPix = bbox.getMinY()
+        self._yMaxPix = bbox.getMaxY()
 
         self._bbox = afwGeom.Box2D(bbox)
 
-        pupilSystem = afwDetector.makeCameraSys(FIELD_ANGLE)
-        pixelSystem = afwDetector.makeCameraSys(PIXELS)
-
-        centerPoint = afwDetector.getCenter(FOCAL_PLANE)
-        centerPupil = afwCamera.transform(centerPoint, pupilSystem).getPoint()
+        centerPupil = self._cameraWrapper.getCenterPupil(self._name)
         self._xCenterArcsec = arcsecFromRadians(centerPupil.getX())
         self._yCenterArcsec = arcsecFromRadians(centerPupil.getY())
-        centerPixel = afwCamera.transform(centerPoint, pixelSystem).getPoint()
 
-        # Again, we want to deal in the Camera team pixel coordinate definitions;
-        # not the DM pixel coordinate definitions
-        self._xCenterPix = centerPixel.getY()
-        self._yCenterPix = centerPixel.getX()
+        centerPixel = self._cameraWrapper.getCenterPixel(self._name)
+        self._xCenterPix = centerPixel.getX()
+        self._yCenterPix = centerPixel.getY()
 
         self._xMinArcsec = None
         self._yMinArcsec = None
         self._xMaxArcsec = None
         self._yMaxArcsec = None
-        cornerPointList = afwDetector.getCorners(FOCAL_PLANE)
-        for cornerPoint in cornerPointList:
-            cameraPoint = afwDetector.makeCameraPoint(cornerPoint, FOCAL_PLANE)
-            cameraPointPupil = afwCamera.transform(cameraPoint, pupilSystem).getPoint()
+
+        for cameraPointPupil in self._cameraWrapper.getCornerPupilList(self._name):
 
             xx = arcsecFromRadians(cameraPointPupil.getX())
             yy = arcsecFromRadians(cameraPointPupil.getY())
@@ -235,19 +235,19 @@ class GalSimDetector(object):
         try:
             assert self._xMaxArcsec-self._xMinArcsec < self._yMaxArcsec-self._yMinArcsec
         except:
-            if afwDetector.getType() != WAVEFRONT and afwDetector.getType() != GUIDER:
+            if self._detector_type != WAVEFRONT and self._detector_type != GUIDER:
                 print('delta xArcsec ',self._xMaxArcsec-self._xMinArcsec)
                 print('delta yArcsec ',self._yMaxArcsec-self._yMinArcsec)
-                print(afwDetector.getName(), afwDetector.getType())
+                print(self._name, self._detector_type)
                 raise
 
         try:
             assert self._xMaxPix-self._xMinPix < self._yMaxPix-self._yMinPix
         except:
-            if afwDetector.getType() != WAVEFRONT and afwDetector.getType() != GUIDER:
+            if self._detector_type != WAVEFRONT and self._detector_type != GUIDER:
                 print('delta xPix ',self._xMaxPix-self._xMinPix)
                 print('delta yPix ',self._yMaxPix-self._yMinPix)
-                print(afwDetector.getName(), afwDetector.getType())
+                print(self._name, self._detector_type)
                 raise
 
     def _getFileName(self):
@@ -259,9 +259,7 @@ class GalSimDetector(object):
         detectorName = detectorName.replace(':', '')
         detectorName = detectorName.replace(' ', '')
         detectorName = detectorName.replace('S', '_S')
-
-        name = detectorName
-        return name
+        return detectorName
 
     def pixelCoordinatesFromRaDec(self, ra, dec):
         """
@@ -285,10 +283,10 @@ class GalSimDetector(object):
             raLocal = np.array([ra])
             decLocal = np.array([dec])
 
-        xPix, yPix = _pixelCoordsFromRaDec(raLocal, decLocal, chipName=nameList,
-                                           obs_metadata=self._obs_metadata,
-                                           epoch=self._epoch,
-                                           camera=self._afwCamera)
+        xPix, yPix = self._cameraWrapper._pixelCoordsFromRaDec(raLocal, decLocal, chipName=nameList,
+                                                               obs_metadata=self._obs_metadata,
+                                                               epoch=self._epoch,
+                                                               camera=self._afwCamera)
 
         return xPix, yPix
 
@@ -316,8 +314,7 @@ class GalSimDetector(object):
             xp = np.array([xPupil])
             yp = np.array([yPupil])
 
-        xPix, yPix = pixelCoordsFromPupilCoords(xp, yp, chipName=nameList,
-                                                camera=self._afwCamera)
+        xPix, yPix = self._cameraWrapper.pixelCoordsFromPupilCoords(xp, yp, chipName=nameList)
 
         return xPix, yPix
 
@@ -507,6 +504,15 @@ class GalSimDetector(object):
                            "just instantiate a new GalSimDetector")
 
     @property
+    def camera_wrapper(self):
+        return self._cameraWrapper
+
+    @camera_wrapper.setter
+    def camera_wrapper(self, value):
+        raise RuntimeError("You should not be setting the camera_wrapper on the fly; "
+                           "just instantiate a new GalSimDetector")
+
+    @property
     def photParams(self):
         """PhotometricParameters instantiation characterizing the detector"""
         return self._photParams
@@ -527,30 +533,10 @@ class GalSimDetector(object):
                            "just instantiate a new GalSimDetector")
 
     @property
-    def afwCamera(self):
-        """afw.cameraGeom.Camera instantiation corresponding to this detector"""
-        return self._afwCamera
-
-    @afwCamera.setter
-    def afwCamera(self, value):
-        raise RuntimeError("You should not be setting afwCamera on the fly; "
-                           "just instantiate a new GalSimDetector")
-
-    @property
-    def afwDetector(self):
-        """afw.cameraGeom.Detector instantiation corresponding to this detector"""
-        return self._afwDetector
-
-    @afwDetector.setter
-    def afwDetector(self, value):
-        raise RuntimeError("You should not be setting afwDetector on the fly; "
-                           "just instantiate a new GalSimDetector")
-
-    @property
     def wcs(self):
         """WCS corresponding to this detector"""
         if self._wcs is None:
-            self._wcs = GalSim_afw_TanSipWCS(self.afwDetector, self.afwCamera,
+            self._wcs = GalSim_afw_TanSipWCS(self._name, self._cameraWrapper,
                                              self.obs_metadata, self.epoch,
                                              photParams=self.photParams)
 

--- a/python/lsst/sims/GalSimInterface/galSimDetector.py
+++ b/python/lsst/sims/GalSimInterface/galSimDetector.py
@@ -272,8 +272,7 @@ class GalSimDetector(object):
 
         xPix, yPix = self._cameraWrapper._pixelCoordsFromRaDec(raLocal, decLocal, chipName=nameList,
                                                                obs_metadata=self._obs_metadata,
-                                                               epoch=self._epoch,
-                                                               camera=self._afwCamera)
+                                                               epoch=self._epoch)
 
         return xPix, yPix
 

--- a/python/lsst/sims/GalSimInterface/galSimDetector.py
+++ b/python/lsst/sims/GalSimInterface/galSimDetector.py
@@ -232,23 +232,6 @@ class GalSimDetector(object):
 
         self._photParams = photParams
         self._fileName = self._getFileName()
-        try:
-            assert self._xMaxArcsec-self._xMinArcsec < self._yMaxArcsec-self._yMinArcsec
-        except:
-            if self._detector_type != WAVEFRONT and self._detector_type != GUIDER:
-                print('delta xArcsec ',self._xMaxArcsec-self._xMinArcsec)
-                print('delta yArcsec ',self._yMaxArcsec-self._yMinArcsec)
-                print(self._name, self._detector_type)
-                raise
-
-        try:
-            assert self._xMaxPix-self._xMinPix < self._yMaxPix-self._yMinPix
-        except:
-            if self._detector_type != WAVEFRONT and self._detector_type != GUIDER:
-                print('delta xPix ',self._xMaxPix-self._xMinPix)
-                print('delta yPix ',self._yMaxPix-self._yMinPix)
-                print(self._name, self._detector_type)
-                raise
 
     def _getFileName(self):
         """

--- a/python/lsst/sims/GalSimInterface/galSimDetector.py
+++ b/python/lsst/sims/GalSimInterface/galSimDetector.py
@@ -526,11 +526,10 @@ class GalSimDetector(object):
                                              self.obs_metadata, self.epoch,
                                              photParams=self.photParams)
 
-            if re.match('R_[0-9]_[0-9]_S_[0-9]_[0-9]', self.fileName) is not None:
+            if re.match('R[0-9][0-9]_S[0-9][0-9]', self.fileName) is not None:
                 # This is an LSST camera; format the FITS header to feed through DM code
 
-                wcsName = self.fileName.replace('_', '')
-                wcsName = wcsName.replace('S', '_S')
+                wcsName = self.fileName
 
                 self._wcs.fitsHeader.set("CHIPID", wcsName)
 

--- a/python/lsst/sims/GalSimInterface/galSimDetector.py
+++ b/python/lsst/sims/GalSimInterface/galSimDetector.py
@@ -5,6 +5,7 @@ import galsim
 import numpy as np
 import lsst.afw.geom as afwGeom
 from lsst.afw.cameraGeom import FIELD_ANGLE, PIXELS, FOCAL_PLANE
+from lsst.afw.cameraGeom import WAVEFRONT, GUIDER
 from lsst.sims.utils import arcsecFromRadians
 from lsst.sims.coordUtils import (_raDecFromPixelCoords,
                                   _pixelCoordsFromRaDec,
@@ -231,6 +232,23 @@ class GalSimDetector(object):
 
         self._photParams = photParams
         self._fileName = self._getFileName()
+        try:
+            assert self._xMaxArcsec-self._xMinArcsec < self._yMaxArcsec-self._yMinArcsec
+        except:
+            if afwDetector.getType() != WAVEFRONT and afwDetector.getType() != GUIDER:
+                print('delta xArcsec ',self._xMaxArcsec-self._xMinArcsec)
+                print('delta yArcsec ',self._yMaxArcsec-self._yMinArcsec)
+                print(afwDetector.getName(), afwDetector.getType())
+                raise
+
+        try:
+            assert self._xMaxPix-self._xMinPix < self._yMaxPix-self._yMinPix
+        except:
+            if afwDetector.getType() != WAVEFRONT and afwDetector.getType() != GUIDER:
+                print('delta xPix ',self._xMaxPix-self._xMinPix)
+                print('delta yPix ',self._yMaxPix-self._yMinPix)
+                print(afwDetector.getName(), afwDetector.getType())
+                raise
 
     def _getFileName(self):
         """

--- a/python/lsst/sims/GalSimInterface/galSimDetector.py
+++ b/python/lsst/sims/GalSimInterface/galSimDetector.py
@@ -240,8 +240,7 @@ class GalSimDetector(object):
         detectorName = self.name
         detectorName = detectorName.replace(',', '')
         detectorName = detectorName.replace(':', '')
-        detectorName = detectorName.replace(' ', '')
-        detectorName = detectorName.replace('S', '_S')
+        detectorName = detectorName.replace(' ', '_')
         return detectorName
 
     def pixelCoordinatesFromRaDec(self, ra, dec):

--- a/python/lsst/sims/GalSimInterface/galSimDetector.py
+++ b/python/lsst/sims/GalSimInterface/galSimDetector.py
@@ -184,11 +184,14 @@ class GalSimDetector(object):
         self._obs_metadata = obs_metadata
         self._epoch = epoch
 
+        # We are transposing the coordinates because of the difference
+        # between how DM defines pixel coordinates and how the
+        # Camera team defines pixel coordinates
         bbox = afwDetector.getBBox()
-        self._xMinPix = bbox.getMinX()
-        self._xMaxPix = bbox.getMaxX()
-        self._yMinPix = bbox.getMinY()
-        self._yMaxPix = bbox.getMaxY()
+        self._xMinPix = bbox.getMinY()
+        self._xMaxPix = bbox.getMaxY()
+        self._yMinPix = bbox.getMinX()
+        self._yMaxPix = bbox.getMaxX()
 
         self._bbox = afwGeom.Box2D(bbox)
 
@@ -200,8 +203,11 @@ class GalSimDetector(object):
         self._xCenterArcsec = arcsecFromRadians(centerPupil.getX())
         self._yCenterArcsec = arcsecFromRadians(centerPupil.getY())
         centerPixel = afwCamera.transform(centerPoint, pixelSystem).getPoint()
-        self._xCenterPix = centerPixel.getX()
-        self._yCenterPix = centerPixel.getY()
+
+        # Again, we want to deal in the Camera team pixel coordinate definitions;
+        # not the DM pixel coordinate definitions
+        self._xCenterPix = centerPixel.getY()
+        self._yCenterPix = centerPixel.getX()
 
         self._xMinArcsec = None
         self._yMinArcsec = None

--- a/python/lsst/sims/GalSimInterface/galSimDetector.py
+++ b/python/lsst/sims/GalSimInterface/galSimDetector.py
@@ -182,6 +182,11 @@ class GalSimDetector(object):
                                "of GalSimCameraWrapper or one of its daughter "
                                "classes")
 
+        if detectorName not in cameraWrapper.camera:
+            raise RuntimeError("detectorName needs to be in the camera wrapped by "
+                               "cameraWrapper when instantiating a GalSimDetector\n"
+                               "%s is not in your cameraWrapper.camera" % detectorName)
+
         if photParams is None:
             raise RuntimeError("You need to specify an instantiation of PhotometricParameters " +
                                "when constructing a GalSimDetector")

--- a/python/lsst/sims/GalSimInterface/galSimDetector.py
+++ b/python/lsst/sims/GalSimInterface/galSimDetector.py
@@ -231,9 +231,10 @@ class GalSimDetector(object):
         Format the name of the detector to add to the name of the FITS file
         """
         detectorName = self.name
-        detectorName = detectorName.replace(',', '_')
-        detectorName = detectorName.replace(':', '_')
-        detectorName = detectorName.replace(' ', '_')
+        detectorName = detectorName.replace(',', '')
+        detectorName = detectorName.replace(':', '')
+        detectorName = detectorName.replace(' ', '')
+        detectorName = detectorName.replace('S', '_S')
 
         name = detectorName
         return name

--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -332,8 +332,8 @@ class GalSimInterpreter(object):
 
                 self.detectorImages[name] = obj.drawImage(method='phot',
                                                           gain=detector.photParams.gain,
-                                                          offset=galsim.PositionD(xPix-detector.xCenterPix,
-                                                                                  yPix-detector.yCenterPix),
+                                                          offset=galsim.PositionD(detector.yCenterPix-yPix,
+                                                                                  xPix-detector.xCenterPix),
                                                           rng=self._rng,
                                                           image=self.detectorImages[name],
                                                           add_to_image=True)
@@ -366,10 +366,8 @@ class GalSimInterpreter(object):
                                     half_light_radius=float(gsObject.halfLightRadiusArcsec))
 
         # Turn the Sersic profile into an ellipse
-        # Add pi/2 to the position angle, because GalSim sets position angle=0
-        # aligned with East, rather than North
         centeredObj = centeredObj.shear(q=gsObject.minorAxisRadians/gsObject.majorAxisRadians,
-                                        beta=(0.5*np.pi+gsObject.positionAngleRadians)*galsim.radians)
+                                        beta=(gsObject.positionAngleRadians)*galsim.radians)
         if self.PSF is not None:
             centeredObj = self.PSF.applyPSF(xPupil=gsObject.xPupilArcsec,
                                             yPupil=gsObject.yPupilArcsec,

--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -320,10 +320,9 @@ class GalSimInterpreter(object):
 
                 name = self._getFileName(detector=detector, bandpassName=bandpassName)
 
-                xPix, yPix = pixelCoordsFromPupilCoords(gsObject.xPupilRadians,
-                                                        gsObject.yPupilRadians,
-                                                        chipName=detector.name,
-                                                        camera=detector.afwCamera)
+                xPix, yPix = detector.camera_wrapper.pixelCoordsFromPupilCoords(gsObject.xPupilRadians,
+                                                                                gsObject.yPupilRadians,
+                                                                                chipName=detector.name)
 
                 obj = centeredObj.copy()
 
@@ -332,8 +331,8 @@ class GalSimInterpreter(object):
 
                 self.detectorImages[name] = obj.drawImage(method='phot',
                                                           gain=detector.photParams.gain,
-                                                          offset=galsim.PositionD(detector.yCenterPix-yPix,
-                                                                                  xPix-detector.xCenterPix),
+                                                          offset=galsim.PositionD(xPix-detector.xCenterPix,
+                                                                                  yPix-detector.yCenterPix),
                                                           rng=self._rng,
                                                           image=self.detectorImages[name],
                                                           add_to_image=True)
@@ -367,7 +366,7 @@ class GalSimInterpreter(object):
 
         # Turn the Sersic profile into an ellipse
         centeredObj = centeredObj.shear(q=gsObject.minorAxisRadians/gsObject.majorAxisRadians,
-                                        beta=(gsObject.positionAngleRadians)*galsim.radians)
+                                        beta=(0.5*np.pi+gsObject.positionAngleRadians)*galsim.radians)
         if self.PSF is not None:
             centeredObj = self.PSF.applyPSF(xPupil=gsObject.xPupilArcsec,
                                             yPupil=gsObject.yPupilArcsec,

--- a/python/lsst/sims/GalSimInterface/wcsUtils/WcsUtils.py
+++ b/python/lsst/sims/GalSimInterface/wcsUtils/WcsUtils.py
@@ -44,7 +44,7 @@ def tanWcsFromDetector(afwDetector, afwCamera, obs_metadata, epoch):
     that the telescope may impose on the image)
 
     @param [in] afwDetector is an instantiation of afw.cameraGeom's Detector
-    class which characterizes the detector for which you wish to return th
+    class which characterizes the detector for which you wish to return the
     WCS
 
     @param [in] afwCamera is an instantiation of afw.cameraGeom's Camera

--- a/python/lsst/sims/GalSimInterface/wcsUtils/WcsUtils.py
+++ b/python/lsst/sims/GalSimInterface/wcsUtils/WcsUtils.py
@@ -69,7 +69,7 @@ def tanWcsFromDetector(afwDetector, afwCamera, obs_metadata, epoch):
     nameList = []
 
     # dx and dy are set somewhat heuristically
-    # setting them eqal to 0.1(max-min) lead to errors
+    # setting them equal to 0.1(max-min) lead to errors
     # on the order of 0.7 arcsec in the WCS
 
     dx = 0.5*(xTanPixMax-xTanPixMin)

--- a/tests/testAllowedChips.py
+++ b/tests/testAllowedChips.py
@@ -10,12 +10,14 @@ from lsst.utils import getPackageDir
 import lsst.afw.cameraGeom.testUtils as camTestUtils
 
 import lsst.afw.image as afwImage
+from lsst.afw.cameraGeom import WAVEFRONT, GUIDER
 from lsst.sims.utils.CodeUtilities import sims_clean_up
 from lsst.sims.utils import ObservationMetaData
 from lsst.sims.catalogs.db import fileDBObject
 from lsst.sims.coordUtils import raDecFromPixelCoords
 from lsst.sims.photUtils import Sed, Bandpass, BandpassDict, PhotometricParameters
 from lsst.sims.GalSimInterface import GalSimStars, SNRdocumentPSF
+from lsst.sims.GalSimInterface import GalSimCameraWrapper
 from testUtils import create_text_catalog
 
 ROOT = os.path.abspath(os.path.dirname(__file__))
@@ -138,18 +140,20 @@ class allowedChipsTest(unittest.TestCase):
         psf = SNRdocumentPSF()
         controlCatalog.setPSF(psf)
         testCatalog.setPSF(psf)
-        controlCatalog.camera = self.camera
-        testCatalog.camera = self.camera
+        controlCatalog.camera_wrapper = GalSimCameraWrapper(self.camera)
+        testCatalog.camera_wrapper = GalSimCameraWrapper(self.camera)
 
         test_root = os.path.join(self.scratchDir, 'allowed_chip_test_image')
         control_root = os.path.join(self.scratchDir, 'allowed_chip_control_image')
 
         name_list = []
         for dd in self.camera:
+            if dd.getType() == WAVEFRONT or dd.getType() == GUIDER:
+                continue
             name = dd.getName()
             name_list.append(name)
-            stripped_name = name.replace(':', '_')
-            stripped_name = stripped_name.replace(',', '_')
+            stripped_name = name.replace(':', '')
+            stripped_name = stripped_name.replace(',', '')
             stripped_name = stripped_name.replace(' ', '_')
 
             test_image_name = os.path.join(self.scratchDir, test_root+'_'+stripped_name+'_u.fits')
@@ -185,8 +189,8 @@ class allowedChipsTest(unittest.TestCase):
             # specified chips.
             # Verify that each image contains the expected amount of flux.
 
-            stripped_name = name.replace(':', '_')
-            stripped_name = stripped_name.replace(',', '_')
+            stripped_name = name.replace(':', '')
+            stripped_name = stripped_name.replace(',', '')
             stripped_name = stripped_name.replace(' ', '_')
 
             test_image_name = os.path.join(self.scratchDir, test_root+'_'+stripped_name+'_u.fits')

--- a/tests/testFWHM.py
+++ b/tests/testFWHM.py
@@ -15,6 +15,7 @@ from lsst.sims.utils import angularSeparation
 from lsst.sims.catalogs.db import fileDBObject
 from lsst.sims.GalSimInterface import GalSimStars, SNRdocumentPSF
 from lsst.sims.GalSimInterface import Kolmogorov_and_Gaussian_PSF
+from lsst.sims.GalSimInterface import GalSimCameraWrapper
 from lsst.sims.coordUtils import raDecFromPixelCoords
 
 from lsst.sims.coordUtils.utils import ReturnCamera
@@ -42,7 +43,6 @@ class fwhmFileDBObj(fileDBObject):
 
 
 class fwhmCat(GalSimStars):
-    camera = ReturnCamera(os.path.join(getPackageDir('sims_GalSimInterface'), 'tests', 'cameraData'))
     bandpassNames = ['u']
 
     default_columns = GalSimStars.default_columns
@@ -159,7 +159,7 @@ class GalSimFwhmTest(unittest.TestCase):
         for fwhm in (0.1, 0.14):
 
             cat = fwhmCat(db, obs_metadata=obs)
-            cat.camera = camera
+            cat.camera_wrapper = GalSimCameraWrapper(camera)
 
             psf = SNRdocumentPSF(fwhm=fwhm, pixel_scale=0.02)
             cat.setPSF(psf)
@@ -218,7 +218,7 @@ class KolmogrovGaussianTestCase(unittest.TestCase):
         db = fwhmFileDBObj(dbFileName, runtable='test')
 
         cat = fwhmCat(db, obs_metadata=obs)
-        cat.camera = camera
+        cat.camera_wrapper = GalSimCameraWrapper(camera)
 
         psf = Kolmogorov_and_Gaussian_PSF(rawSeeing=0.7, airmass=1.05, band='g')
         cat.setPSF(psf)

--- a/tests/testFitsHeaders.py
+++ b/tests/testFitsHeaders.py
@@ -12,8 +12,10 @@ from lsst.sims.utils.CodeUtilities import sims_clean_up
 from lsst.sims.utils import ObservationMetaData
 from lsst.sims.catalogs.db import fileDBObject
 from lsst.sims.GalSimInterface import GalSimStars, SNRdocumentPSF
+from lsst.sims.GalSimInterface import GalSimCameraWrapper
+from lsst.sims.GalSimInterface import LSSTCameraWrapper
 from lsst.sims.coordUtils.utils import ReturnCamera
-from lsst.obs.lsstSim import LsstSimMapper
+from lsst.sims.coordUtils import lsst_camera
 
 from testUtils import create_text_catalog
 
@@ -59,6 +61,7 @@ class FitsHeaderTest(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         sims_clean_up()
+        del lsst_camera._lsst_camera
 
     def testFitsHeader(self):
         """
@@ -68,7 +71,6 @@ class FitsHeaderTest(unittest.TestCase):
         image created with the cartoon camera does not
         """
 
-        lsstCamera = LsstSimMapper().camera
         cameraDir = os.path.join(getPackageDir('sims_GalSimInterface'), 'tests', 'cameraData')
         cartoonCamera = ReturnCamera(cameraDir)
 
@@ -92,7 +94,7 @@ class FitsHeaderTest(unittest.TestCase):
 
         # first test the lsst camera
         lsstCat = fitsHeaderCatalog(db, obs_metadata=obs)
-        lsstCat.camera = lsstCamera
+        lsstCat.camera_wrapper = LSSTCameraWrapper()
         lsstCat.PSF = SNRdocumentPSF()
         lsstCat.write_catalog(lsst_cat_name)
         lsstCat.write_images(nameRoot=lsst_cat_root)
@@ -119,7 +121,7 @@ class FitsHeaderTest(unittest.TestCase):
 
         # now test with the cartoon camera
         cartoonCat = fitsHeaderCatalog(db, obs_metadata=obs)
-        cartoonCat.camera = cartoonCamera
+        cartoonCat.camera_wrapper = GalSimCameraWrapper(cartoonCamera)
         cartoonCat.PSF = SNRdocumentPSF()
         cartoonCat.write_catalog(cartoon_cat_name)
         cartoonCat.write_images(nameRoot=cartoon_cat_root)

--- a/tests/testGalSimCameraWrapper.py
+++ b/tests/testGalSimCameraWrapper.py
@@ -25,6 +25,8 @@ def setup_module(module):
 
 class Camera_Wrapper_Test_Class(unittest.TestCase):
 
+    longMessage = True
+
     def test_generic_camera_wrapper(self):
         """
         Test that GalSimCameraWrapper wraps its methods as expected.

--- a/tests/testGalSimCameraWrapper.py
+++ b/tests/testGalSimCameraWrapper.py
@@ -12,6 +12,8 @@ from lsst.sims.coordUtils import pupilCoordsFromPixelCoords
 from lsst.sims.coordUtils import pixelCoordsFromPupilCoords
 
 from lsst.sims.GalSimInterface import GalSimCameraWrapper
+from lsst.sims.GalSimInterface import LSSTCameraWrapper
+from lsst.sims.coordUtils import lsst_camera
 
 import lsst.afw.cameraGeom.testUtils as camTestUtils
 from lsst.afw.cameraGeom import FOCAL_PLANE
@@ -180,6 +182,182 @@ class Camera_Wrapper_Test_Class(unittest.TestCase):
             np.testing.assert_array_equal(y_pix, y_pix_wrapper)
 
         del camera
+
+    def test_LSST_camera_wrapper(self):
+        """
+        Test that LSSTCameraWrapper wraps its methods as expected.
+
+        Recall that the LSSTCameraWrapper applies the 90 degree rotation
+        to go from DM pixel coordinates to Camera team pixel coordinates.
+        Namely,
+
+        Camera +y = DM +x
+        Camera +x = DM -y
+        """
+        camera = lsst_camera()
+        camera_wrapper = LSSTCameraWrapper()
+
+        obs_mjd = ObservationMetaData(mjd=60000.0)
+        ra, dec = raDecFromAltAz(35.0, 112.0, obs_mjd)
+        obs = ObservationMetaData(pointingRA=ra, pointingDec=dec,
+                                  mjd=obs_mjd.mjd,
+                                  rotSkyPos=22.4)
+
+        rng = np.random.RandomState(8124)
+
+        for detector in camera:
+            name = detector.getName()
+            bbox = camera[name].getBBox()
+            bbox_wrapper = camera_wrapper.getBBox(name)
+            self.assertEqual(bbox.getMinX(), bbox_wrapper.getMinY())
+            self.assertEqual(bbox.getMaxX(), bbox_wrapper.getMaxY())
+            self.assertEqual(bbox.getMinY(), bbox_wrapper.getMinX())
+            self.assertEqual(bbox.getMaxY(), bbox_wrapper.getMaxX())
+            self.assertGreater(bbox_wrapper.getMaxY()-bbox_wrapper.getMinY(),
+                               bbox_wrapper.getMaxX()-bbox_wrapper.getMinX())
+
+            center_point = camera[name].getCenter(FOCAL_PLANE)
+            pixel_system = camera[name].makeCameraSys(PIXELS)
+            center_pix = camera.transform(center_point, pixel_system).getPoint()
+            center_pix_wrapper = camera_wrapper.getCenterPixel(name)
+            self.assertEqual(center_pix.getX(), center_pix_wrapper.getY())
+            self.assertEqual(center_pix.getY(), center_pix_wrapper.getX())
+
+            # Note that DM and the Camera team agree on the orientation
+            # of the pupil coordinate/field angle axes
+            pupil_system = camera[name].makeCameraSys(PUPIL)
+            center_pupil = camera.transform(center_point, pupil_system).getPoint()
+            center_pupil_wrapper = camera_wrapper.getCenterPupil(name)
+            self.assertEqual(center_pupil.getX(), center_pupil_wrapper.getX())
+            self.assertEqual(center_pupil.getY(), center_pupil_wrapper.getY())
+
+            corner_pupil_wrapper = camera_wrapper.getCornerPupilList(name)
+            corner_point_list = camera[name].getCorners(FOCAL_PLANE)
+            for point in corner_point_list:
+                camera_point = camera[name].makeCameraPoint(point, FOCAL_PLANE)
+                camera_point_pupil = camera.transform(camera_point, pupil_system).getPoint()
+                dd_min = 1.0e10
+                for wrapper_point in corner_pupil_wrapper:
+                    dd = np.sqrt((camera_point_pupil.getX()-wrapper_point.getX())**2 +
+                                 (camera_point_pupil.getY()-wrapper_point.getY())**2)
+
+                    if dd < dd_min:
+                        dd_min = dd
+                self.assertLess(dd_min, 1.0e-20)
+
+            xpix_min = None
+            xpix_max = None
+            ypix_min = None
+            ypix_max = None
+            tan_pix_system = camera[name].makeCameraSys(TAN_PIXELS)
+            for point in corner_point_list:
+                camera_point = camera[name].makeCameraPoint(point, FOCAL_PLANE)
+                pixel_point = camera.transform(camera_point, tan_pix_system).getPoint()
+                xx = pixel_point.getX()
+                yy = pixel_point.getY()
+                if xpix_min is None or xx<xpix_min:
+                    xpix_min = xx
+                if ypix_min is None or yy<ypix_min:
+                    ypix_min = yy
+                if xpix_max is None or xx>xpix_max:
+                    xpix_max = xx
+                if ypix_max is None or yy>ypix_max:
+                    ypix_max = yy
+
+            pix_bounds_wrapper = camera_wrapper.getTanPixelBounds(name)
+            self.assertEqual(pix_bounds_wrapper[0], ypix_min)
+            self.assertEqual(pix_bounds_wrapper[1], ypix_max)
+            self.assertEqual(pix_bounds_wrapper[2], xpix_min)
+            self.assertEqual(pix_bounds_wrapper[3], xpix_max)
+
+            # generate some random pupil coordinates;
+            # verify that the relationship between the DM and Camera team
+            # pixel coordinates corresponding to those pupil coordinates
+            # is as expected
+            x_pup = rng.random_sample(10)*0.005-0.01
+            y_pup = rng.random_sample(10)*0.005-0.01
+            x_pix, y_pix = pixelCoordsFromPupilCoords(x_pup, y_pup, chipName=name,
+                                                      camera=camera)
+
+            (x_pix_wrapper,
+             y_pix_wrapper) = camera_wrapper.pixelCoordsFromPupilCoords(x_pup, y_pup,
+                                                                        chipName=name)
+
+            nan_x = np.where(np.isnan(x_pix))
+            self.assertEqual(len(nan_x[0]), 0)
+            np.testing.assert_allclose(x_pix-center_pix.getX(),
+                                       y_pix_wrapper-center_pix_wrapper.getY(),
+                                       atol=1.0e-10, rtol=0.0)
+            np.testing.assert_allclose(y_pix-center_pix.getY(),
+                                       center_pix_wrapper.getX()-x_pix_wrapper,
+                                       atol=1.0e-10, rtol=0.0)
+
+            # use camera_wrapper.pupilCoordsFromPixelCoords to go back to pupil
+            # coordinates from x_pix_wrapper, y_pix_wrapper; make sure you get
+            # the original pupil coordinates back out
+            (x_pup_wrapper,
+             y_pup_wrapper) = camera_wrapper.pupilCoordsFromPixelCoords(x_pix_wrapper,
+                                                                        y_pix_wrapper,
+                                                                        chipName=name)
+            msg = 'worst error %e' % np.abs(x_pup-x_pup_wrapper).max()
+            np.testing.assert_allclose(x_pup, x_pup_wrapper, atol=1.0e-10, rtol=0.0, err_msg=msg)
+            msg = 'worst error %e' % np.abs(y_pup-y_pup_wrapper).max()
+            np.testing.assert_allclose(y_pup, y_pup_wrapper, atol=1.0e-10, rtol=0.0, err_msg=msg)
+
+            # generate some random sky coordinates; verify that the methods that
+            # convert between (RA, Dec) and pixel coordinates behave as expected.
+            # NOTE: x_pix, y_pix will be in DM pixel coordinate convention
+            x_pix = bbox.getMinX() + rng.random_sample(10)*(bbox.getMaxX()-bbox.getMinX())
+            y_pix = bbox.getMinY() + rng.random_sample(10)*(bbox.getMaxY()-bbox.getMinY())
+
+            ra, dec = raDecFromPixelCoords(x_pix, y_pix, name, camera=camera,
+                                           obs_metadata=obs)
+
+            (ra_wrapper,
+             dec_wrapper) = camera_wrapper.raDecFromPixelCoords(2.0*center_pix.getY()-y_pix,
+                                                                x_pix, name, obs)
+
+            nan_ra = np.where(np.isnan(ra))
+            self.assertEqual(len(nan_ra[0]), 0)
+            np.testing.assert_allclose(ra, ra_wrapper, atol=1.0e-10, rtol=0.0)
+            np.testing.assert_allclose(dec, dec_wrapper, atol=1.0e-10, rtol=0.0)
+
+            # make sure that the method that returns RA, Dec in radians agrees with
+            # the method that returns RA, Dec in degrees
+            (ra_rad,
+             dec_rad) = camera_wrapper._raDecFromPixelCoords(2.0*center_pix.getY()-y_pix,
+                                                             x_pix, name, obs)
+
+            np.testing.assert_allclose(np.radians(ra_wrapper), ra_rad, atol=1.0e-10, rtol=0.0)
+            np.testing.assert_allclose(np.radians(dec_wrapper), dec_rad, atol=1.0e-10, rtol=0.0)
+
+            # Go back to pixel coordinates with pixelCoordsFromRaDec; verify that
+            # the result relates to the original DM pixel coordinates as expected
+            # (x_pix_inv, y_pix_inv will be in Camera pixel coordinates)
+            (x_pix_inv,
+             y_pix_inv) = camera_wrapper.pixelCoordsFromRaDec(ra_wrapper, dec_wrapper,
+                                                              chipName=name,
+                                                              obs_metadata=obs)
+
+            np.testing.assert_allclose(y_pix_inv, x_pix, atol=1.0e-5, rtol=0.0)
+            np.testing.assert_allclose(x_pix_inv, 2.0*center_pix.getY()-y_pix, atol=1.0e-5, rtol=0.0)
+
+            ra = np.radians(ra_wrapper)
+            dec = np.radians(dec_wrapper)
+
+            # check that the the method that accepts RA, Dec in radians agrees with the
+            # method that accepts RA, Dec in degrees
+            (x_pix_wrapper,
+             y_pix_wrapper) = camera_wrapper._pixelCoordsFromRaDec(ra, dec, chipName=name,
+                                                                   obs_metadata=obs)
+
+            np.testing.assert_allclose(x_pix_inv, x_pix_wrapper, atol=1.0e-10, rtol=0.0)
+            np.testing.assert_allclose(y_pix_inv, y_pix_wrapper, atol=1.0e-10, rtol=0.0)
+
+        del camera
+        del camera_wrapper
+        del lsst_camera._lsst_camera
+
 
 
 class MemoryTestClass(lsst.utils.tests.MemoryTestCase):

--- a/tests/testGalSimCameraWrapper.py
+++ b/tests/testGalSimCameraWrapper.py
@@ -25,7 +25,8 @@ class Camera_Wrapper_Test_Class(unittest.TestCase):
 
     def test_generic_camera_wrapper(self):
         """
-        Test that GalSimCameraWrapper wraps its methods as expected
+        Test that GalSimCameraWrapper wraps its methods as expected.
+        This is mostly to catch changes in afw API.
         """
         camera = camTestUtils.CameraWrapper().camera
         camera_wrapper = GalSimCameraWrapper(camera)

--- a/tests/testGalSimCameraWrapper.py
+++ b/tests/testGalSimCameraWrapper.py
@@ -1,0 +1,190 @@
+import unittest
+import numpy as np
+import lsst.utils.tests
+
+from lsst.sims.utils import ObservationMetaData
+from lsst.sims.utils import raDecFromAltAz
+from lsst.sims.coordUtils import pixelCoordsFromRaDec
+from lsst.sims.coordUtils import _pixelCoordsFromRaDec
+from lsst.sims.coordUtils import raDecFromPixelCoords
+from lsst.sims.coordUtils import _raDecFromPixelCoords
+from lsst.sims.coordUtils import pupilCoordsFromPixelCoords
+from lsst.sims.coordUtils import pixelCoordsFromPupilCoords
+
+from lsst.sims.GalSimInterface import GalSimCameraWrapper
+
+import lsst.afw.cameraGeom.testUtils as camTestUtils
+from lsst.afw.cameraGeom import FOCAL_PLANE
+from lsst.afw.cameraGeom import TAN_PIXELS, PUPIL, PIXELS
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+class Camera_Wrapper_Test_Class(unittest.TestCase):
+
+    def test_generic_camera_wrapper(self):
+        """
+        Test that GalSimCameraWrapper wraps its methods as expected
+        """
+        camera = camTestUtils.CameraWrapper().camera
+        camera_wrapper = GalSimCameraWrapper(camera)
+
+        obs_mjd = ObservationMetaData(mjd=60000.0)
+        ra, dec = raDecFromAltAz(35.0, 112.0, obs_mjd)
+        obs = ObservationMetaData(pointingRA=ra, pointingDec=dec,
+                                  mjd=obs_mjd.mjd,
+                                  rotSkyPos=22.4)
+
+        rng = np.random.RandomState(8124)
+
+        for detector in camera:
+            name = detector.getName()
+            bbox = camera[name].getBBox()
+            bbox_wrapper = camera_wrapper.getBBox(name)
+            self.assertEqual(bbox.getMinX(), bbox_wrapper.getMinX())
+            self.assertEqual(bbox.getMaxX(), bbox_wrapper.getMaxX())
+            self.assertEqual(bbox.getMinY(), bbox_wrapper.getMinY())
+            self.assertEqual(bbox.getMaxY(), bbox_wrapper.getMaxY())
+
+            center_point = camera[name].getCenter(FOCAL_PLANE)
+            pixel_system = camera[name].makeCameraSys(PIXELS)
+            center_pix = camera.transform(center_point, pixel_system).getPoint()
+            center_pix_wrapper = camera_wrapper.getCenterPixel(name)
+            self.assertEqual(center_pix.getX(), center_pix_wrapper.getX())
+            self.assertEqual(center_pix.getY(), center_pix_wrapper.getY())
+
+            pupil_system = camera[name].makeCameraSys(PUPIL)
+            center_pupil = camera.transform(center_point, pupil_system).getPoint()
+            center_pupil_wrapper = camera_wrapper.getCenterPupil(name)
+            self.assertEqual(center_pupil.getX(), center_pupil_wrapper.getX())
+            self.assertEqual(center_pupil.getY(), center_pupil_wrapper.getY())
+
+            corner_pupil_wrapper = camera_wrapper.getCornerPupilList(name)
+            corner_point_list = camera[name].getCorners(FOCAL_PLANE)
+            for point in corner_point_list:
+                camera_point = camera[name].makeCameraPoint(point, FOCAL_PLANE)
+                camera_point_pupil = camera.transform(camera_point, pupil_system).getPoint()
+                dd_min = 1.0e10
+                for wrapper_point in corner_pupil_wrapper:
+                    dd = np.sqrt((camera_point_pupil.getX()-wrapper_point.getX())**2 +
+                                 (camera_point_pupil.getY()-wrapper_point.getY())**2)
+
+                    if dd < dd_min:
+                        dd_min = dd
+                self.assertLess(dd_min, 1.0e-20)
+
+            xpix_min = None
+            xpix_max = None
+            ypix_min = None
+            ypix_max = None
+            tan_pix_system = camera[name].makeCameraSys(TAN_PIXELS)
+            for point in corner_point_list:
+                camera_point = camera[name].makeCameraPoint(point, FOCAL_PLANE)
+                pixel_point = camera.transform(camera_point, tan_pix_system).getPoint()
+                xx = pixel_point.getX()
+                yy = pixel_point.getY()
+                if xpix_min is None or xx<xpix_min:
+                    xpix_min = xx
+                if ypix_min is None or yy<ypix_min:
+                    ypix_min = yy
+                if xpix_max is None or xx>xpix_max:
+                    xpix_max = xx
+                if ypix_max is None or yy>ypix_max:
+                    ypix_max = yy
+
+            pix_bounds_wrapper = camera_wrapper.getTanPixelBounds(name)
+            self.assertEqual(pix_bounds_wrapper[0], xpix_min)
+            self.assertEqual(pix_bounds_wrapper[1], xpix_max)
+            self.assertEqual(pix_bounds_wrapper[2], ypix_min)
+            self.assertEqual(pix_bounds_wrapper[3], ypix_max)
+
+            x_pup = rng.random_sample(10)*0.005-0.01
+            y_pup = rng.random_sample(10)*0.005-0.01
+            x_pix, y_pix = pixelCoordsFromPupilCoords(x_pup, y_pup, chipName=name,
+                                                      camera=camera)
+
+            (x_pix_wrapper,
+             y_pix_wrapper) = camera_wrapper.pixelCoordsFromPupilCoords(x_pup, y_pup,
+                                                                        chipName=name)
+
+            nan_x = np.where(np.isnan(x_pix))
+            self.assertEqual(len(nan_x[0]), 0)
+            np.testing.assert_array_equal(x_pix, x_pix_wrapper)
+            np.testing.assert_array_equal(y_pix, y_pix_wrapper)
+
+            x_pix = rng.random_sample(10)*100.0-200.0
+            y_pix = rng.random_sample(10)*100.0-200.0
+            x_pup, y_pup = pupilCoordsFromPixelCoords(x_pix, y_pix, chipName=name,
+                                                      camera=camera)
+
+            (x_pup_wrapper,
+             y_pup_wrapper) = camera_wrapper.pupilCoordsFromPixelCoords(x_pix, y_pix, chipName=name)
+
+            nan_x = np.where(np.isnan(x_pup))
+            self.assertEqual(len(nan_x[0]), 0)
+            np.testing.assert_array_equal(x_pup, x_pup_wrapper)
+            np.testing.assert_array_equal(y_pup, y_pup_wrapper)
+
+            ra, dec = raDecFromPixelCoords(x_pix, y_pix, name, camera=camera,
+                                           obs_metadata=obs)
+
+            (ra_wrapper,
+             dec_wrapper) = camera_wrapper.raDecFromPixelCoords(x_pix, y_pix, name, obs)
+
+            nan_ra = np.where(np.isnan(ra))
+            self.assertEqual(len(nan_ra[0]), 0)
+            np.testing.assert_array_equal(ra, ra_wrapper)
+            np.testing.assert_array_equal(dec, dec_wrapper)
+
+            ra, dec = _raDecFromPixelCoords(x_pix, y_pix, name, camera=camera,
+                                            obs_metadata=obs)
+
+            (ra_wrapper,
+             dec_wrapper) = camera_wrapper._raDecFromPixelCoords(x_pix, y_pix, name, obs)
+
+            nan_ra = np.where(np.isnan(ra))
+            self.assertEqual(len(nan_ra[0]), 0)
+            np.testing.assert_array_equal(ra, ra_wrapper)
+            np.testing.assert_array_equal(dec, dec_wrapper)
+
+            ra = obs.pointingRA + (rng.random_sample(10)*50.0-100.0)/60.0
+            dec = obs.pointingDec + (rng.random_sample(10)*50.0-100.0)/60.0
+
+            x_pix, y_pix = pixelCoordsFromRaDec(ra, dec, chipName=name, camera=camera,
+                                                obs_metadata=obs)
+
+            (x_pix_wrapper,
+             y_pix_wrapper) = camera_wrapper.pixelCoordsFromRaDec(ra, dec, chipName=name,
+                                                                  obs_metadata=obs)
+
+            nan_x = np.where(np.isnan(x_pix))
+            self.assertEqual(len(nan_x[0]), 0)
+            np.testing.assert_array_equal(x_pix, x_pix_wrapper)
+            np.testing.assert_array_equal(y_pix, y_pix_wrapper)
+
+            ra = np.radians(ra)
+            dec = np.radians(dec)
+
+            x_pix, y_pix = _pixelCoordsFromRaDec(ra, dec, chipName=name, camera=camera,
+                                                 obs_metadata=obs)
+
+            (x_pix_wrapper,
+             y_pix_wrapper) = camera_wrapper._pixelCoordsFromRaDec(ra, dec, chipName=name,
+                                                                   obs_metadata=obs)
+
+            nan_x = np.where(np.isnan(x_pix))
+            self.assertEqual(len(nan_x[0]), 0)
+            np.testing.assert_array_equal(x_pix, x_pix_wrapper)
+            np.testing.assert_array_equal(y_pix, y_pix_wrapper)
+
+        del camera
+
+
+class MemoryTestClass(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/testGalSimCameraWrapper.py
+++ b/tests/testGalSimCameraWrapper.py
@@ -17,7 +17,7 @@ from lsst.sims.coordUtils import lsst_camera
 
 import lsst.afw.cameraGeom.testUtils as camTestUtils
 from lsst.afw.cameraGeom import FOCAL_PLANE
-from lsst.afw.cameraGeom import TAN_PIXELS, PUPIL, PIXELS
+from lsst.afw.cameraGeom import TAN_PIXELS, FIELD_ANGLE, PIXELS
 
 def setup_module(module):
     lsst.utils.tests.init()
@@ -59,7 +59,7 @@ class Camera_Wrapper_Test_Class(unittest.TestCase):
             self.assertEqual(center_pix.getX(), center_pix_wrapper.getX())
             self.assertEqual(center_pix.getY(), center_pix_wrapper.getY())
 
-            pupil_system = camera[name].makeCameraSys(PUPIL)
+            pupil_system = camera[name].makeCameraSys(FIELD_ANGLE)
             center_pupil = camera.transform(center_point, pupil_system).getPoint()
             center_pupil_wrapper = camera_wrapper.getCenterPupil(name)
             self.assertEqual(center_pupil.getX(), center_pupil_wrapper.getX())
@@ -227,7 +227,7 @@ class Camera_Wrapper_Test_Class(unittest.TestCase):
 
             # Note that DM and the Camera team agree on the orientation
             # of the pupil coordinate/field angle axes
-            pupil_system = camera[name].makeCameraSys(PUPIL)
+            pupil_system = camera[name].makeCameraSys(FIELD_ANGLE)
             center_pupil = camera.transform(center_point, pupil_system).getPoint()
             center_pupil_wrapper = camera_wrapper.getCenterPupil(name)
             self.assertEqual(center_pupil.getX(), center_pupil_wrapper.getX())

--- a/tests/testGalSimDetector.py
+++ b/tests/testGalSimDetector.py
@@ -10,7 +10,7 @@ from lsst.sims.utils import ObservationMetaData
 from lsst.sims.photUtils import PhotometricParameters
 from lsst.sims.coordUtils.utils import ReturnCamera
 from lsst.sims.coordUtils import _raDecFromPixelCoords, pupilCoordsFromPixelCoords
-from lsst.sims.GalSimInterface import GalSimDetector
+from lsst.sims.GalSimInterface import GalSimDetector, GalSimCameraWrapper
 
 
 def setup_module(module):
@@ -51,7 +51,8 @@ class GalSimDetectorTest(unittest.TestCase):
         """
 
         photParams = PhotometricParameters()
-        gsdet = GalSimDetector(self.camera[0], self.camera,
+        gsdet = GalSimDetector(self.camera[0].getName(),
+                               GalSimCameraWrapper(self.camera),
                                self.obs, self.epoch,
                                photParams=photParams)
 
@@ -99,7 +100,8 @@ class GalSimDetectorTest(unittest.TestCase):
         """
 
         photParams = PhotometricParameters()
-        gsdet = GalSimDetector(self.camera[0], self.camera,
+        gsdet = GalSimDetector(self.camera[0].getName(),
+                               GalSimCameraWrapper(self.camera),
                                self.obs, self.epoch,
                                photParams=photParams)
 

--- a/tests/testGalSimInterface.py
+++ b/tests/testGalSimInterface.py
@@ -792,7 +792,7 @@ class GalSimInterfaceTest(unittest.TestCase):
         cat2 = testStarCatalog(stars, obs_metadata=obs_metadata2)
         cat2.copyGalSimInterpreter(cat1)
         cat2.write_catalog(catName, write_header=False, write_mode='a')
-        self.catalogTester(catName=catName, catalog=cat2, nameRoot='compound')
+        self.catalogTester(catName=catName, catalog=cat2, nameRoot='compound_one_empty')
 
         if os.path.exists(dbName1):
             os.unlink(dbName1)

--- a/tests/testGalSimPhoSimCatalogs.py
+++ b/tests/testGalSimPhoSimCatalogs.py
@@ -8,11 +8,12 @@ import shutil
 import lsst.utils.tests
 
 from lsst.utils import getPackageDir
+import lsst.afw.cameraGeom.testUtils as camTestUtils
 from lsst.sims.utils.CodeUtilities import sims_clean_up
 from lsst.sims.utils import ObservationMetaData, radiansFromArcsec
 from lsst.sims.catalogs.db import fileDBObject
 from lsst.sims.GalSimInterface import GalSimPhoSimGalaxies, GalSimPhoSimStars, GalSimPhoSimAgn
-from lsst.sims.GalSimInterface import SNRdocumentPSF
+from lsst.sims.GalSimInterface import SNRdocumentPSF, GalSimCameraWrapper
 from lsst.sims.catUtils.exampleCatalogDefinitions import (PhoSimCatalogSersic2D, PhoSimCatalogPoint,
                                                           PhoSimCatalogZPoint)
 
@@ -31,6 +32,7 @@ class GalSimPhoSimTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        cls.camera = camTestUtils.CameraWrapper().camera
         cls.dataDir = tempfile.mkdtemp(dir=ROOT, prefix='GalSimPhoSimTest-')
         cls.n_objects = 5
         rng = np.random.RandomState(45)
@@ -194,6 +196,7 @@ class GalSimPhoSimTest(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         sims_clean_up()
+        del cls.camera
 
         if os.path.exists(cls.bulge_name):
             os.unlink(cls.bulge_name)
@@ -225,6 +228,7 @@ class GalSimPhoSimTest(unittest.TestCase):
         db.objectTypeId = 55
 
         gs_cat = GalSimPhoSimGalaxies(db, obs_metadata=self.obs)
+        gs_cat.camera_wrapper = GalSimCameraWrapper(self.camera)
         gs_cat.bandpassNames = self.obs.bandpass
         gs_cat.PSF = SNRdocumentPSF()
         gs_cat.phoSimHeaderMap = {}

--- a/tests/testOutputWcs.py
+++ b/tests/testOutputWcs.py
@@ -13,6 +13,7 @@ from lsst.sims.utils import ObservationMetaData, arcsecFromRadians
 from lsst.sims.utils import haversine
 from lsst.sims.catalogs.db import fileDBObject
 from lsst.sims.GalSimInterface import GalSimStars, SNRdocumentPSF
+from lsst.sims.GalSimInterface import GalSimCameraWrapper
 from lsst.sims.coordUtils import _raDecFromPixelCoords
 
 from lsst.sims.coordUtils.utils import ReturnCamera
@@ -39,7 +40,6 @@ class outputWcsFileDBObj(fileDBObject):
 
 
 class outputWcsCat(GalSimStars):
-    camera = ReturnCamera(os.path.join(getPackageDir('sims_GalSimInterface'), 'tests', 'cameraData'))
     bandpassNames = ['u']
 
     default_columns = GalSimStars.default_columns
@@ -102,7 +102,7 @@ class GalSimOutputWcsTest(unittest.TestCase):
             db = outputWcsFileDBObj(dbFileName, runtable='test')
 
             cat = outputWcsCat(db, obs_metadata=obs)
-            cat.camera = camera
+            cat.camera_wrapper = GalSimCameraWrapper(camera)
 
             psf = SNRdocumentPSF(fwhm=fwhm)
             cat.setPSF(psf)

--- a/tests/testPlacement.py
+++ b/tests/testPlacement.py
@@ -16,6 +16,7 @@ from lsst.sims.coordUtils import _pixelCoordsFromRaDec, _raDecFromPixelCoords
 from lsst.sims.photUtils import Sed, Bandpass
 from lsst.sims.catalogs.db import fileDBObject
 from lsst.sims.GalSimInterface import GalSimStars, SNRdocumentPSF
+from lsst.sims.GalSimInterface import GalSimCameraWrapper
 from testUtils import create_text_catalog
 
 ROOT = os.path.abspath(os.path.dirname(__file__))
@@ -202,12 +203,12 @@ class GalSimPlacementTest(unittest.TestCase):
                                 mag_norm=[self.magNorm]*len(xDisplacementList))
             db = placementFileDBObj(dbFileName, runtable='test')
             cat = placementCatalog(db, obs_metadata=obs)
+            cat.camera_wrapper = GalSimCameraWrapper(camera)
             if actualCounts is None:
                 actualCounts = controlSed.calcADU(uBandpass, cat.photParams)
 
             psf = SNRdocumentPSF(fwhm=fwhm)
             cat.setPSF(psf)
-            cat.camera = camera
 
             cat.write_catalog(catName)
             cat.write_images(nameRoot=imageRoot)

--- a/tests/testPositionAngle.py
+++ b/tests/testPositionAngle.py
@@ -115,7 +115,7 @@ class GalSimPositionAngleTest(unittest.TestCase):
 
         # find the angle between the (1,1) vector in pixel space and the
         # north axis of the image
-        theta = np.arctan2(-1.0*(raCenterP1[0]-raCenter[0]), decCenterP1[0]-decCenter[0])
+        theta = np.arctan2((raCenterP1[0]-raCenter[0]), decCenterP1[0]-decCenter[0])
 
         # rotate the (1,1) vector in pixel space so that it is pointing
         # along the north axis
@@ -123,7 +123,7 @@ class GalSimPositionAngleTest(unittest.TestCase):
         north = north/np.sqrt(north[0]*north[0]+north[1]*north[1])
 
         # find the east axis of the image
-        east = np.array([-1.0*north[1], north[0]])
+        east = np.array([north[1], -1.0*north[0]])
 
         # now find the covariance matrix of the x, y  pixel space distribution
         # of flux on the image

--- a/tests/testPositionAngle.py
+++ b/tests/testPositionAngle.py
@@ -11,6 +11,7 @@ from lsst.sims.utils.CodeUtilities import sims_clean_up
 from lsst.sims.utils import ObservationMetaData, radiansFromArcsec
 from lsst.sims.catalogs.db import fileDBObject
 from lsst.sims.GalSimInterface import GalSimGalaxies
+from lsst.sims.GalSimInterface import GalSimCameraWrapper
 from lsst.sims.coordUtils import _raDecFromPixelCoords
 
 from lsst.sims.coordUtils.utils import ReturnCamera
@@ -40,7 +41,6 @@ class paFileDBObj(fileDBObject):
 
 
 class paCat(GalSimGalaxies):
-    camera = ReturnCamera(os.path.join(getPackageDir('sims_GalSimInterface'), 'tests', 'cameraData'))
     bandpassNames = ['u']
     default_columns = [('sedFilename', 'sed_flat.txt', (str, 12)),
                        ('magNorm', 21.0, float),
@@ -201,7 +201,7 @@ class GalSimPositionAngleTest(unittest.TestCase):
             db = paFileDBObj(dbFileName, runtable='test')
 
             cat = paCat(db, obs_metadata=obs)
-            cat.camera = camera
+            cat.camera_wrapper = GalSimCameraWrapper(camera)
 
             cat.write_catalog(catName)
             cat.write_images(nameRoot=imageRoot)


### PR DESCRIPTION
As documented here

https://github.com/LSSTDESC/SSim_DC1/issues/36

the PhoSim e-image WCS and the DM-generated WCS are off by a 90 degree rotation.  This pull request allows us to use sims_GalSimInterface to generate images with the PhoSim e-image WCS by wrapping the `GalSimCatalog.camera` object in a `GalSimCameraWrapper` class that gives the user the option of re-mapping the pixel space coordinate conversions to account for this rotation.  This process is explained in the module-level dosctring of `galSimCameraWrapper.py`.

This pull request comes with supporting pull requests in sims_utils, sims_coordUtils, and sims_catUtils. 