### PR TITLE
close FITS files after reading them in

### DIFF
--- a/tests/testFitsHeaders.py
+++ b/tests/testFitsHeaders.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 import os
 import numpy as np
 import unittest

--- a/tests/testFitsHeaders.py
+++ b/tests/testFitsHeaders.py
@@ -103,15 +103,14 @@ class FitsHeaderTest(unittest.TestCase):
             true_name = os.path.join(outputDir, file_name)
             if lsst_cat_root in true_name:
                 ct += 1
-                fitsTest = fits.open(true_name)
-                header = fitsTest[0].header
-                self.assertIn('CHIPID', header)
-                self.assertIn('OBSID', header)
-                self.assertIn('OUTFILE', header)
-                self.assertEqual(header['OBSID'], 112)
-                self.assertEqual(header['CHIPID'], 'R22_S11')
-                self.assertEqual(header['OUTFILE'], 'lsst_e_112_f0_R22_S11_E000')
-                fitsTest.close()
+                with fits.open(true_name) as fitsTest:
+                    header = fitsTest[0].header
+                    self.assertIn('CHIPID', header)
+                    self.assertIn('OBSID', header)
+                    self.assertIn('OUTFILE', header)
+                    self.assertEqual(header['OBSID'], 112)
+                    self.assertEqual(header['CHIPID'], 'R22_S11')
+                    self.assertEqual(header['OUTFILE'], 'lsst_e_112_f0_R22_S11_E000')
                 os.unlink(true_name)
 
         self.assertGreater(ct, 0)
@@ -130,12 +129,11 @@ class FitsHeaderTest(unittest.TestCase):
             true_name = os.path.join(outputDir, file_name)
             if cartoon_cat_root in true_name:
                 ct += 1
-                fitsTest = fits.open(true_name)
-                header = fitsTest[0].header
-                self.assertNotIn('CHIPID', header)
-                self.assertNotIn('OBSID', header)
-                self.assertNotIn('OUTFILE', header)
-                fitsTest.close()
+                with fits.open(true_name) as fitsTest:
+                    header = fitsTest[0].header
+                    self.assertNotIn('CHIPID', header)
+                    self.assertNotIn('OBSID', header)
+                    self.assertNotIn('OUTFILE', header)
                 os.unlink(true_name)
 
         self.assertGreater(ct, 0)

--- a/tests/testFitsHeaders.py
+++ b/tests/testFitsHeaders.py
@@ -1,3 +1,4 @@
+from __future__ import with_statement
 import os
 import numpy as np
 import unittest

--- a/tests/testFitsHeaders.py
+++ b/tests/testFitsHeaders.py
@@ -111,6 +111,7 @@ class FitsHeaderTest(unittest.TestCase):
                 self.assertEqual(header['OBSID'], 112)
                 self.assertEqual(header['CHIPID'], 'R22_S11')
                 self.assertEqual(header['OUTFILE'], 'lsst_e_112_f0_R22_S11_E000')
+                fitsTest.close()
                 os.unlink(true_name)
 
         self.assertGreater(ct, 0)
@@ -134,6 +135,7 @@ class FitsHeaderTest(unittest.TestCase):
                 self.assertNotIn('CHIPID', header)
                 self.assertNotIn('OBSID', header)
                 self.assertNotIn('OUTFILE', header)
+                fitsTest.close()
                 os.unlink(true_name)
 
         self.assertGreater(ct, 0)

--- a/tests/testGalSimInterface.py
+++ b/tests/testGalSimInterface.py
@@ -523,7 +523,7 @@ class GalSimInterfaceTest(unittest.TestCase):
         cat.write_catalog(catName)
         bandpassDir = os.path.join(getPackageDir('sims_catUtils'), 'tests', 'testThroughputs')
         sedDir = os.path.join(getPackageDir('sims_catUtils'), 'tests', 'testSeds')
-        self.catalogTester(catName=catName, catalog=cat, nameRoot='fakeBandpass',
+        self.catalogTester(catName=catName, catalog=cat, nameRoot='fakeSed',
                            bandpassDir=bandpassDir, bandpassRoot='fakeTotal_',
                            sedDir=sedDir)
 


### PR DESCRIPTION
in testFitsHeaders.py. Otherwise, resources are left open
on NFS-mounted machines, causing shutil.rmtree(outputDir)
to raise an exception