### PR TITLE
Update galSimCatalogs.py

### DIFF
--- a/python/lsst/sims/GalSimInterface/galSimCatalogs.py
+++ b/python/lsst/sims/GalSimInterface/galSimCatalogs.py
@@ -220,7 +220,7 @@ class GalSimBase(InstanceCatalog, CameraCoords):
 
         Objects are stored based on their uniqueId values.
         """
-        self.objectHasBeenDrawn = []
+        self.objectHasBeenDrawn = set()
         self._initializeGalSimInterpreter()
         self.hasBeenInitialized = True
 
@@ -389,7 +389,7 @@ class GalSimBase(InstanceCatalog, CameraCoords):
                 raise RuntimeError('Trying to draw an object with SED == None')
             else:
 
-                self.objectHasBeenDrawn.append(name)
+                self.objectHasBeenDrawn.add(name)
 
                 flux_dict = {}
                 for bb in self.bandpassNames:


### PR DESCRIPTION
When the number of objects is large checking if an object is in self.objectHasBeenDrawn starts to take a long time, because it is a list which must be searched in linear time.

This PR changes it to a set which can be searched in constant time.  I couldn't find anywhere else in the code where self.objectHasBeenDrawn is referenced.
