### PR TITLE
add chipName option to addNoiseAndBackground to support sky bg spatial variation

### DIFF
--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -313,7 +313,8 @@ class GalSimInterpreter(object):
                                                                     m5=self.obs_metadata.m5[bandpassName],
                                                                     FWHMeff=
                                                                     self.obs_metadata.seeing[bandpassName],
-                                                                    photParams=detector.photParams)
+                                                                    photParams=detector.photParams,
+                                                                    chipName=detector.name)
 
         for bandpassName in self.bandpassDict:
 

--- a/python/lsst/sims/GalSimInterface/galSimNoiseAndBackground.py
+++ b/python/lsst/sims/GalSimInterface/galSimNoiseAndBackground.py
@@ -75,7 +75,7 @@ class NoiseAndBackgroundBase(object):
 
     def addNoiseAndBackground(self, image, bandpass=None, m5=None,
                               FWHMeff=None,
-                              photParams=None):
+                              photParams=None, chipName=None):
         """
         This method actually adds the sky background and noise to an image.
 
@@ -95,7 +95,13 @@ class NoiseAndBackgroundBase(object):
         PhotometricParameters class that carries details about the
         photometric response of the telescope.  Defaults to None.
 
+        @param [in] chipName is the name of the sensor being
+        considered, e.g., "R:2,2 S:1,1".  It is not used in this base
+        class, but it's provided as an option in this interface for
+        possible use by subclasses.
+
         @param [out] the input image with the background and noise model added to it.
+
         """
 
 


### PR DESCRIPTION
This is to support this [pull request](https://github.com/LSSTDESC/imSim/pull/81) in the imSim repo.