### PR TITLE
limit memory usage for bright objects by setting maxN=int(1e6) in drawImage calls

### DIFF
--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -336,6 +336,7 @@ class GalSimInterpreter(object):
                                                           offset=galsim.PositionD(xPix-detector.xCenterPix,
                                                                                   yPix-detector.yCenterPix),
                                                           rng=self._rng,
+                                                          maxN=int(1e6),
                                                           image=self.detectorImages[name],
                                                           add_to_image=True)
 
@@ -678,6 +679,7 @@ class GalSimSiliconInterpeter(GalSimInterpreter):
                     obj.drawImage(method='phot',
                                   offset=offset,
                                   rng=self._rng,
+                                  maxN=int(1e6),
                                   image=my_image[bounds],
                                   sensor=sensor,
                                   surface_ops=surface_ops,


### PR DESCRIPTION
For the brightest stars in the DC2 instance catalogs (up to `magNorm = 10`), the flux exceeds 1e9 photons which causes >10GB of memory to be used by the `gsobject.drawImage` function.  Setting `maxN=int(1e6)` limits the memory required by that function to less than ~200MB without noticeable slowdown.