### PR TITLE
Add centroid file capability. 

### DIFF
--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -781,12 +781,6 @@ class GalSimSiliconInterpeter(GalSimInterpreter):
                                           gsObject.flux(bandpassName), xPix, yPix)
                         self.centroid_list.append(centroid_tuple)
 
-                else:
-                    # There should be none of these, but add a warning
-                    # just in case.
-                    warnings.warn('Object %s has folding_threshold %s. Skipped.'
-                                  % (gsObject.uniqueId, object_on_image.gsparams.folding_threshold))
-
         self.drawn_objects.add(gsObject.uniqueId)
         self.write_checkpoint()
         return outputString

--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -16,11 +16,11 @@ import pickle
 import numpy as np
 import galsim
 from lsst.sims.utils import radiansFromArcsec
-from lsst.sims.coordUtils import pixelCoordsFromPupilCoords
 from lsst.sims.GalSimInterface import make_galsim_detector, SNRdocumentPSF, \
     Kolmogorov_and_Gaussian_PSF
 
 __all__ = ["make_gs_interpreter", "GalSimInterpreter", "GalSimSiliconInterpeter"]
+
 
 def make_gs_interpreter(obs_md, detectors, bandpassDict, noiseWrapper,
                         epoch=None, seed=None, apply_sensor_model=False):
@@ -149,7 +149,7 @@ class GalSimInterpreter(object):
         else:
             return False
 
-    def _writeObjectToCentroidFile(gsObject, detector, bandpassName):
+    def _writeObjectToCentroidFile(self, gsObject, detector, bandpassName, xPix, yPix):
         """
         Write the flux and the the object position on the sensor for this object
         into a centroid file.  First check if a centroid file exists for this
@@ -474,9 +474,9 @@ class GalSimInterpreter(object):
             psf = self.PSF
         # Seeds the random walk with the object id if available
         if gsObject.uniqueId is None:
-            rng=None
+            rng = None
         else:
-            rng=galsim.BaseDeviate(int(gsObject.uniqueId))
+            rng = galsim.BaseDeviate(int(gsObject.uniqueId))
 
         # Create the RandomWalk profile
         centeredObj = galsim.RandomWalk(npoints=int(gsObject.npoints),

--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -520,7 +520,7 @@ class GalSimInterpreter(object):
 
         return namesWritten
 
-    def open_centroid_file(self, detector_name):
+    def open_centroid_file(self, centroid_name):
         """
         Open a centroid file.  This file will have one line per-object and the
         it will be labeled with the objectID and then followed by the average X
@@ -530,10 +530,10 @@ class GalSimInterpreter(object):
         """
 
         visitID = self.obs_metadata.OpsimMetaData['obshistID']
-        file_name = self.centroid_base_name + str(visitID) + '_' + detector_name + '.txt'
+        file_name = self.centroid_base_name + str(visitID) + '_' + centroid_name + '.txt'
 
-        self.centroid_handles[detector_name] = open(file_name, 'w')
-        self.centroid_handles[detector_name].write('{:15} {:>15} {:>10} {:>10}\n'.
+        self.centroid_handles[centroid_name] = open(file_name, 'w')
+        self.centroid_handles[centroid_name].write('{:15} {:>15} {:>10} {:>10}\n'.
                                                    format('SourceID', 'Flux', 'xPix', 'yPix'))
 
     def _writeObjectToCentroidFile(self, detector_name, bandpass_name, uniqueId, flux, xPix, yPix):

--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -565,19 +565,18 @@ class GalSimInterpreter(object):
         """
         Write the centroid data structure out to the files.
 
-        This funnction loops over the entries in the centroid list and
+        This function loops over the entries in the centroid list and
         then sends them each to be writen to a file. The
         _writeObjectToCentroidFile will decide how to put them in files.
+
+        After writing the files are closed.
         """
         # Loop over entries
         for centroid_tuple in self.centroid_list:
             (detector_name, bandpass_name, uniqueId, flux, xPix, yPix) = centroid_tuple
             self._writeObjectToCentroidFile(detector_name, bandpass_name, uniqueId, flux, xPix, yPix)
 
-    def close_centroid_files(self):
-        """
-        Close the centroid file.
-        """
+        # Now close the centroid files.
         for name in self.centroid_handles:
             self.centroid_handles[name].close()
 

--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -348,7 +348,8 @@ class GalSimInterpreter(object):
 
                 # If we are writing centroid files, store the entry.
                 if self.centroid_base_name is not None:
-                    centroid_tuple = (gsObject, detector, bandpassName, xPix, yPix)
+                    centroid_tuple = (detector.fileName, bandpassName, gsObject.uniqueId,
+                                      gsObject.flux(bandpassName), xPix, yPix)
                     self.centroid_list.append(centroid_tuple)
 
         self.drawn_objects.add(gsObject.uniqueId)
@@ -535,21 +536,22 @@ class GalSimInterpreter(object):
         self.centroid_handles[detector_name].write('{:15} {:>15} {:>10} {:>10}\n'.
                                                    format('SourceID', 'Flux', 'xPix', 'yPix'))
 
-    def _writeObjectToCentroidFile(self, gsObject, detector, bandpassName, xPix, yPix):
+    def _writeObjectToCentroidFile(self, detector_name, bandpass_name, uniqueId, flux, xPix, yPix):
         """
         Write the flux and the the object position on the sensor for this object
         into a centroid file.  First check if a centroid file exists for this
         detector and, if it doesn't create it.
 
-        @param [in] gsObject is an instantiation of the GalSimCelestialObject class
-        carrying information about the object whose image is to be drawnself.
-
-        @param [in] detector is an instantation of a detector object (a sensor).
+        @param [in] detectorName is the name of the sensor the gsObject falls on.
 
         @param [in] bandpassName is the name of the filter used in this exposure.
+
+        @param [in] UniqueID is the Unique ID of the gsObject.
+
+        @param [in] flux is the calculated flux for the gsObject in the given bandPass.
         """
 
-        centroid_name = detector.fileName + '_' + bandpassName
+        centroid_name = detector_name + '_' + bandpass_name
 
         # If we haven't seen this sensor before open a centroid file for it.
         if centroid_name not in self.centroid_handles:
@@ -557,9 +559,7 @@ class GalSimInterpreter(object):
 
         # Write the object to the file
         self.centroid_handles[centroid_name].write('{:<15d} {:15.5f} {:10.2f} {:10.2f}\n'.
-                                                   format(gsObject.uniqueId,
-                                                          gsObject.flux(bandpassName),
-                                                          xPix, yPix))
+                                                   format(uniqueId, flux, xPix, yPix))
 
     def write_centroid_files(self):
         """
@@ -571,8 +571,8 @@ class GalSimInterpreter(object):
         """
         # Loop over entries
         for centroid_tuple in self.centroid_list:
-            (gsObject, detector, bandpassName, xPix, yPix) = centroid_tuple
-            self._writeObjectToCentroidFile(gsObject, detector, bandpassName, xPix, yPix)
+            (detector_name, bandpass_name, uniqueId, flux, xPix, yPix) = centroid_tuple
+            self._writeObjectToCentroidFile(detector_name, bandpass_name, uniqueId, flux, xPix, yPix)
 
     def close_centroid_files(self):
         """
@@ -643,7 +643,7 @@ class GalSimInterpreter(object):
                 self.detectorImages[key] += image_state['images'][key]
             self._rng = image_state['rng']
             self.drawn_objects = image_state['drawn_objects']
-            self.centroid_list = image_state['centroid_list']
+            self.centroid_list = image_state['centroid_objects']
 
 
 class GalSimSiliconInterpeter(GalSimInterpreter):
@@ -777,7 +777,8 @@ class GalSimSiliconInterpeter(GalSimInterpreter):
 
                     # If we are writing centroid files,store the entry.
                     if self.centroid_base_name is not None:
-                        centroid_tuple = (gsObject, detector, bandpassName, xPix, yPix)
+                        centroid_tuple = (detector.fileName, bandpassName, gsObject.uniqueId,
+                                          gsObject.flux(bandpassName), xPix, yPix)
                         self.centroid_list.append(centroid_tuple)
 
                 else:

--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -573,8 +573,7 @@ class GalSimInterpreter(object):
         """
         # Loop over entries
         for centroid_tuple in self.centroid_list:
-            (detector_name, bandpass_name, uniqueId, flux, xPix, yPix) = centroid_tuple
-            self._writeObjectToCentroidFile(detector_name, bandpass_name, uniqueId, flux, xPix, yPix)
+            self._writeObjectToCentroidFile(*centroid_tuple)
 
         # Now close the centroid files.
         for name in self.centroid_handles:

--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -757,6 +757,18 @@ class GalSimSiliconInterpeter(GalSimInterpreter):
                                   add_to_image=True,
                                   gain=detector.photParams.gain)
 
+                    # If we are writing centroid files, make an entry in the
+                    # approriate file.
+                    if self.centroid_base_name is not None:
+                        self._writeObjectToCentroidFile(gsObject, detector,
+                                                        bandpassName, xPix, yPix)
+
+                else:
+                    # There should be none of these, but add a warning
+                    # just in case.
+                    warnings.warn('Object %s has folding_threshold %s. Skipped.'
+                                  % (gsObject.uniqueId, object_on_image.gsparams.folding_threshold))
+
         self.drawn_objects.add(gsObject.uniqueId)
         self.write_checkpoint()
         return outputString

--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -569,12 +569,6 @@ class GalSimInterpreter(object):
         then sends them each to be writen to a file. The
         _writeObjectToCentroidFile will decide how to put them in files.
         """
-        import sys
-
-        # How much memory is this taking?
-        print('Centroid List takes', sys.getsizeof(self.centroid_list)/1024, 'Mbs,'
-              , "and is", len(self.centroid_list), "elements long.")
-
         # Loop over entries
         for centroid_tuple in self.centroid_list:
             (gsObject, detector, bandpassName, xPix, yPix) = centroid_tuple
@@ -604,7 +598,8 @@ class GalSimInterpreter(object):
                       in self.detectorImages.items()}
             image_state = dict(images=images,
                                rng=self._rng,
-                               drawn_objects=self.drawn_objects)
+                               drawn_objects=self.drawn_objects,
+                               centroid_objects=self.centroid_list)
             with open(self.checkpoint_file, 'wb') as output:
                 pickle.dump(image_state, output)
 
@@ -648,6 +643,7 @@ class GalSimInterpreter(object):
                 self.detectorImages[key] += image_state['images'][key]
             self._rng = image_state['rng']
             self.drawn_objects = image_state['drawn_objects']
+            self.centroid_list = image_state['centroid_list']
 
 
 class GalSimSiliconInterpeter(GalSimInterpreter):

--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -372,17 +372,7 @@ class GalSimInterpreter(object):
 
                 # If we are writing centroid files, make an entry in the approriate file.
                 if self.centroid_base_name is not None:
-
-                    centroid_name = detector.fileName + '_' + bandpassName
-                    # If we haven't seen this sensor before open a centroid file for it.
-                    if centroid_name not in self.centroid_handles:
-                        self.open_centroid_file(centroid_name)
-
-                    # Write the object to the file
-                    self.centroid_handles[centroid_name].write('{:<15d} {:15.5f} {:10.2f} {:10.2f}\n'.
-                                                     format(gsObject.uniqueId,
-                                                            gsObject.flux(bandpassName),
-                                                            xPix, yPix))
+                    self._writeObjectToCentroidFile(gsObject, detector, bandpassName, xPix, yPix)
 
         self.drawn_objects.add(gsObject.uniqueId)
         self.write_checkpoint()

--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -149,8 +149,33 @@ class GalSimInterpreter(object):
         else:
             return False
 
-    def findAllDetectors(self, gsObject):
+    def _writeObjectToCentroidFile(gsObject, detector, bandpassName):
+        """
+        Write the flux and the the object position on the sensor for this object
+        into a centroid file.  First check if a centroid file exists for this
+        detector and, if it doesn't create it.
 
+        @param [in] gsObject is an instantiation of the GalSimCelestialObject class
+        carrying information about the object whose image is to be drawnself.
+
+        @param [in] detector is an instantation of a detector object (a sensor).
+
+        @param [in] bandpassName is the name of the filter used in this exposure.
+        """
+
+        centroid_name = detector.fileName + '_' + bandpassName
+
+        # If we haven't seen this sensor before open a centroid file for it.
+        if centroid_name not in self.centroid_handles:
+            self.open_centroid_file(centroid_name)
+
+        # Write the object to the file
+        self.centroid_handles[centroid_name].write('{:<15d} {:15.5f} {:10.2f} {:10.2f}\n'.
+                                                   format(gsObject.uniqueId,
+                                                          gsObject.flux(bandpassName),
+                                                          xPix, yPix))
+
+    def findAllDetectors(self, gsObject):
         """
         Find all of the detectors on which a given astronomical object casts light.
 

--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -556,7 +556,7 @@ class GalSimInterpreter(object):
 
         self.centroid_handles[detector_name] = open(file_name, 'w')
         self.centroid_handles[detector_name].write('{:15} {:>15} {:>10} {:>10}\n'.
-                                          format('SourceID', 'Photons', 'xpos', 'ypos'))
+                                          format('SourceID', 'Flux', 'xPix', 'yPix'))
 
     def close_centroid_files(self):
         """


### PR DESCRIPTION
This PR adds centroid capability and is driven by imSim code.   There aren't that many changes but the part that opens, closes and writes to files is here in sims_GalSimInterface. See https://github.com/LSSTDESC/imSim/pull/112.  More information is copied from that PR below including current limitations.

-----

I am working on adding more pixel level truth to the simulation but thought it would be useful to first add basic 'centroid file' capability.  

My work on adding information based on what each object looks like on the sensor is currently adding a lot of CPU run time and I need more work to optimize it.  So, this initial PR uses only truth information about the objects in the centroid file.   This makes it more difficult to use this to do imSim/PhoSim validation comparisons (because the PhoSim centroid values are average X and Y values on the sensor) but it is better for comparing catalog truth with the sensor since the true values are not affected by being near the edge of the sensor etc.

This code will make centroid files corresponding to each fits file in the output directory.  For example:

```
wasabi:fits % ls
centroid_197356_R22_S01_r.txt	lsst_e_197356_R22_S01_r.fits
centroid_197356_R22_S10_r.txt	lsst_e_197356_R22_S10_r.fits
centroid_197356_R22_S11_r.txt	lsst_e_197356_R22_S11_r.fits
centroid_197356_R22_S12_r.txt	lsst_e_197356_R22_S12_r.fits
centroid_197356_R22_S21_r.txt	lsst_e_197356_R22_S21_r.fits
```

With a small piece of code this can be converted into a ds9 region file for overlay.  This pandas code example puts a circle at each true object position with the radius scaled by the log of the number of photons for one of the centroid files:

```
import math
import numpy as np
import pandas as pd

centroids = pd.read_csv('fits/centroid_197356_R22_S11_r.txt', delim_whitespace=True, comment="#")

with open('region_file.reg','w') as outfile:
    outfile.write('physical\n')
    centroids.query('Photons>0').to_string(outfile, columns=['xpos','ypos','Photons'], 
                                           header=False, index=False,
                                           formatters=['circle {:10.3f}'.format,
                                                       '{:10.3f}'.format,
                                                       lambda x: '{:10.3f}'.format(math.log(x))])
```

Loading this regions file after loading the fits file results in:

<img width="860" alt="screen shot 2018-05-06 at 12 12 42 am" src="https://user-images.githubusercontent.com/5562740/39664760-2480bb06-50c3-11e8-8ae7-630acb935cc4.png">

To my eye, there is a small shift between the circle centers and the objects.  I'm not sure if this is a plotting issue, a misunderstanding on my part of the variables I used, or some small bug in the code.

The imSim code only sets the options to turn this on and sets the file prefix in the config file.  The code to open, close and write to the files is in sims_GalSimInterface. I will open a separate PR there.

Currently, this code only is in the non-sensor version of the GalSimInterpreter class.  I would like some feedback from @jchiang87, @rmjarvis and @danielsf before I add much more to make this approach seems reasonable to people.

I started by making this look like a PhoSim centroid file since I thought this might make things easier on the people running the pipeline but in principle we could also add more information into the file.