### PR TITLE
add pointing info to detector FITS headers

### DIFF
--- a/python/lsst/sims/GalSimInterface/galSimDetector.py
+++ b/python/lsst/sims/GalSimInterface/galSimDetector.py
@@ -81,6 +81,14 @@ class GalSim_afw_TanSipWCS(galsim.wcs.CelestialWCS):
         if self.photParams is not None:
             self.fitsHeader.set("EXPTIME", self.photParams.nexp*self.photParams.exptime)
 
+        # Add pointing information to FITS header.
+        if self.obs_metadata.pointingRA is not None:
+            self.fitsHeader.set('RATEL', obs_metadata.pointingRA)
+        if self.obs_metadata.pointingDec is not None:
+            self.fitsHeader.set('DECTEL', obs_metadata.pointingDec)
+        if self.obs_metadata.rotSkyPos is not None:
+            self.fitsHeader.set('ROTANGLE', obs_metadata.rotSkyPos)
+
         self.crpix1 = self.fitsHeader.get("CRPIX1")
         self.crpix2 = self.fitsHeader.get("CRPIX2")
 

--- a/tests/testGalSimDetector.py
+++ b/tests/testGalSimDetector.py
@@ -140,6 +140,27 @@ class GalSimDetectorTest(unittest.TestCase):
         for c, t in zip(correctAnswer, testAnswer):
             self.assertIs(c, t)
 
+    def testFitsHeaderKeywords(self):
+        """
+        Test that the FITS header keywords with the observing information
+        are set correctly.
+        """
+        photParams = PhotometricParameters()
+        gsdet = GalSimDetector(self.camera[0].getName(),
+                               GalSimCameraWrapper(self.camera),
+                               self.obs, self.epoch,
+                               photParams=photParams)
+        self.assertEqual(gsdet.wcs.fitsHeader.getScalar('MJD-OBS'),
+                         self.obs.mjd.TAI)
+        self.assertEqual(gsdet.wcs.fitsHeader.getScalar('EXPTIME'),
+                         photParams.nexp*photParams.exptime)
+        self.assertEqual(gsdet.wcs.fitsHeader.getScalar('RATEL'),
+                         self.obs.pointingRA)
+        self.assertEqual(gsdet.wcs.fitsHeader.getScalar('DECTEL'),
+                         self.obs.pointingDec)
+        self.assertEqual(gsdet.wcs.fitsHeader.getScalar('ROTANGLE'),
+                         self.obs.rotSkyPos)
+
 
 class MemoryTestClass(lsst.utils.tests.MemoryTestCase):
     pass


### PR DESCRIPTION
This info will enable the imSim script to generate ingestible `raw` files for `obs_lsstCam` from the eimage files.