### PR TITLE
use temp file to ensure checkpoint file atomicity

### DIFF
--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -13,6 +13,7 @@ import math
 from builtins import object
 import os
 import pickle
+import tempfile
 import numpy as np
 import galsim
 from lsst.sims.utils import radiansFromArcsec
@@ -598,8 +599,11 @@ class GalSimInterpreter(object):
                                rng=self._rng,
                                drawn_objects=self.drawn_objects,
                                centroid_objects=self.centroid_list)
-            with open(self.checkpoint_file, 'wb') as output:
-                pickle.dump(image_state, output)
+            with tempfile.NamedTemporaryFile(mode='wb', delete=False,
+                                             dir='.') as tmp:
+                pickle.dump(image_state, tmp)
+                os.fsync(tmp.fileno())
+            os.rename(tmp.name, self.checkpoint_file)
 
     def restore_checkpoint(self, camera_wrapper, phot_params, obs_metadata,
                            epoch=2000.0):

--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -602,6 +602,7 @@ class GalSimInterpreter(object):
             with tempfile.NamedTemporaryFile(mode='wb', delete=False,
                                              dir='.') as tmp:
                 pickle.dump(image_state, tmp)
+                tmp.flush()
                 os.fsync(tmp.fileno())
             os.rename(tmp.name, self.checkpoint_file)
 


### PR DESCRIPTION
These changes will help prevent partially written checkpoint files in cases where the job times out when running imsim in batch.