### PR TITLE
implement GalSimInterpreter.drawFitsImage enable rendering of FITS images

### DIFF
--- a/python/lsst/sims/GalSimInterface/galSimCatalogs.py
+++ b/python/lsst/sims/GalSimInterface/galSimCatalogs.py
@@ -369,7 +369,8 @@ class GalSimBase(InstanceCatalog, CameraCoords):
                     gsObj = GalSimCelestialObject(self.galsim_type, xp, yp,
                                                   hlr, minor, major, pa, sn,
                                                   ss, self.bandpassDict, self.photParams,
-                                                  npo, gam1, gam2, kap, uniqueId=name)
+                                                  npo, None, None, None,
+                                                  gam1, gam2, kap, uniqueId=name)
 
                     # actually draw the object
                     detectorsString = self.galSimInterpreter.drawObject(gsObj)

--- a/python/lsst/sims/GalSimInterface/galSimCelestialObject.py
+++ b/python/lsst/sims/GalSimInterface/galSimCelestialObject.py
@@ -16,9 +16,11 @@ class GalSimCelestialObject(object):
     def __init__(self, galSimType, xPupil, yPupil,
                  halfLightRadius, minorAxis, majorAxis, positionAngle,
                  sindex, sed, bp_dict, photParams, npoints,
+                 fits_image_file, pixel_scale, rotation_angle,
                  gamma1=0, gamma2=0, kappa=0, uniqueId=None):
         """
-        @param [in] galSimType is a string, either 'pointSource', 'sersic' or 'RandomWalk' denoting the shape of the object
+        @param [in] galSimType is a string, either 'pointSource', 'sersic',
+        'RandomWalk', or 'FitsImage' denoting the shape of the object
 
         @param [in] xPupil is the x pupil coordinate of the object in radians
 
@@ -51,6 +53,13 @@ class GalSimCelestialObject(object):
 
         @param [in] npoints is the number of point sources in a RandomWalk
 
+        @param [in] fits_image_file is the filename for the FitsImage
+
+        @param [in] pixel_scale is the pixel size in arcsec of the FitsImage
+
+        @param [in] rotation_angle is the rotation angle in degrees for
+        the FitsImage
+
         @param [in] gamma1 is the real part of the WL shear parameter
 
         @param [in] gamma2 is the imaginary part of the WL shear parameter
@@ -72,6 +81,9 @@ class GalSimCelestialObject(object):
         self._positionAngleRadians = positionAngle
         self._sindex = sindex
         self._npoints = npoints
+        self._fits_image_file = fits_image_file
+        self._pixel_scale = pixel_scale
+        self._rotation_angle = rotation_angle
         # The galsim.lens(...) function wants to be passed reduced
         # shears and magnification, so convert the WL parameters as
         # defined in phosim instance catalogs to these values.  See
@@ -216,6 +228,33 @@ class GalSimCelestialObject(object):
     def npoints(self, value):
         raise RuntimeError("You should not be setting npoints on the fly; " \
         + "just instantiate a new GalSimCelestialObject")
+
+    @property
+    def fits_image_file(self):
+        return self._fits_image_file
+
+    @fits_image_file.setter
+    def fits_image_file(self, value):
+        raise RuntimeError("You should not be setting fits_image_file on the fly; "
+                           "just instantiate a new GalSimCelestialObject")
+
+    @property
+    def pixel_scale(self):
+        return self._pixel_scale
+
+    @pixel_scale.setter
+    def pixel_scale(self, value):
+        raise RuntimeError("You should not be setting pixel_scale on the fly; "
+                           "just instantiate a new GalSimCelestialObject")
+
+    @property
+    def rotation_angle(self):
+        return self._rotation_angle
+
+    @rotation_angle.setter
+    def rotation_angle(self, value):
+        raise RuntimeError("You should not be setting rotation_angle on the fly; "
+                           "just instantiate a new GalSimCelestialObject")
 
     @property
     def g1(self):

--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -470,6 +470,35 @@ class GalSimInterpreter(object):
 
         return centeredObj
 
+    def drawFitsImage(self, gsObject, psf=None):
+        """
+        Draw the image of a FitsImage light profile.
+
+        @param [in] gsObject is an instantiation of the GalSimCelestialObject class
+        carrying information about the object whose image is to be drawn
+
+        @param [in] psf PSF to use for the convolution.  If None, then use self.PSF.
+        """
+        if psf is None:
+            psf = self.PSF
+
+        # Create the galsim.InterpolatedImage profile from the FITS image.
+        centeredObj = galsim.InterpolatedImage(gsObject.fits_image_file,
+                                               scale=gsObject.pixel_scale)
+        if gsObject.rotation_angle != 0:
+            centeredObj = centeredObj.rotate(gsObject.rotation_angle*galsim.degrees)
+
+        # Apply weak lensing distortion.
+        centerObject = centeredObj.lens(gsObject.g1, gsObject.g2, gsObject.mu)
+
+        # Apply the PSF
+        if psf is not None:
+            centeredObj = psf.applyPSF(xPupil=gsObject.xPupilArcsec,
+                                       yPupil=gsObject.yPupilArcsec,
+                                       obj=centeredObj)
+
+        return centeredObj
+
     def createCenteredObject(self, gsObject, psf=None):
         """
         Create a centered GalSim Object (i.e. if we were just to draw this object as an image,
@@ -490,6 +519,9 @@ class GalSimInterpreter(object):
 
         elif gsObject.galSimType == 'RandomWalk':
             centeredObj = self.drawRandomWalk(gsObject, psf=psf)
+
+        elif gsObject.galSimType == 'FitsImage':
+            centeredObj = self.drawFitsImage(gsObject, psf=psf)
 
         else:
             print("Apologies: the GalSimInterpreter does not yet have a method to draw ")

--- a/tests/testGalSimInterface.py
+++ b/tests/testGalSimInterface.py
@@ -1142,8 +1142,9 @@ class GetStampBoundsTestCase(unittest.TestCase):
         gs_interpreter = make_gs_interpreter(obs_md, ['R:2,2 S:1,1'], None,
                                              None, apply_sensor_model=True)
 
-        gsobject = GalSimCelestialObject('pointSource', 0, 0, 1e-7, 1e-7, 0, 1,
-                                         'none', dict(), None, 0, 0)
+        gsobject = GalSimCelestialObject('pointSource', 0, 0, 1e-7, 1e-7, 1e-7,
+                                         0, 1, 'none', dict(), None, 0, '',
+                                         0.01, 0)
 
         # Make a reference psf that should be the same as used in
         # .getStampBounds.


### PR DESCRIPTION
These changes work with the [`issue/83/static_lens_images`](https://github.com/LSSTDESC/imSim/tree/issue/83/static_lens_images) branch of `imSim`.  @danielsf It looks like there may need to be additional work in `galSimCatalogs.py` to support the changes to `GalSimCelestialObject`, but it wasn't clear to me exactly what's needed.