### PR TITLE
enable uniqueId strings to be written to centroid file

### DIFF
--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -608,7 +608,7 @@ class GalSimInterpreter(object):
             self.open_centroid_file(centroid_name)
 
         # Write the object to the file
-        self.centroid_handles[centroid_name].write('{:<15d} {:15.5f} {:10.2f} {:10.2f}\n'.
+        self.centroid_handles[centroid_name].write('{:<15} {:15.5f} {:10.2f} {:10.2f}\n'.
                                                    format(uniqueId, flux, xPix, yPix))
 
     def write_centroid_files(self):


### PR DESCRIPTION
This change supports using strings that are not cast-able as `int`s for object ids of instance catalog entries.