### PR TITLE
U/danielsf/fix/180920

### DIFF
--- a/python/lsst/sims/GalSimInterface/galSimDetector.py
+++ b/python/lsst/sims/GalSimInterface/galSimDetector.py
@@ -89,14 +89,14 @@ class GalSim_afw_TanSipWCS(galsim.wcs.CelestialWCS):
         if self.obs_metadata.rotSkyPos is not None:
             self.fitsHeader.set('ROTANGLE', obs_metadata.rotSkyPos)
 
-        self.crpix1 = self.fitsHeader.get("CRPIX1")
-        self.crpix2 = self.fitsHeader.get("CRPIX2")
+        self.crpix1 = self.fitsHeader.getScalar("CRPIX1")
+        self.crpix2 = self.fitsHeader.getScalar("CRPIX2")
 
         self.afw_crpix1 = self.crpix1
         self.afw_crpix2 = self.crpix2
 
-        self.crval1 = self.fitsHeader.get("CRVAL1")
-        self.crval2 = self.fitsHeader.get("CRVAL2")
+        self.crval1 = self.fitsHeader.getScalar("CRVAL1")
+        self.crval2 = self.fitsHeader.getScalar("CRVAL2")
 
         self.origin = galsim.PositionD(x=self.crpix1, y=self.crpix2)
         self._color = None
@@ -170,7 +170,7 @@ class GalSim_afw_TanSipWCS(galsim.wcs.CelestialWCS):
 
     def _writeHeader(self, header, bounds):
         for key in self.fitsHeader.getOrderedNames():
-            header[key] = self.fitsHeader.get(key)
+            header[key] = self.fitsHeader.getScalar(key)
 
         return header
 

--- a/tests/testGalSimInterface.py
+++ b/tests/testGalSimInterface.py
@@ -1108,8 +1108,8 @@ class CheckPointingTestCase(unittest.TestCase):
             self.assertEqual(new_img.wcs.crval2, gs_img.wcs.crval2)
             self.assertEqual(new_img.wcs.detectorName, gs_img.wcs.detectorName)
             for name in new_img.wcs.fitsHeader.names():
-                self.assertEqual(new_img.wcs.fitsHeader.get(name),
-                                 gs_img.wcs.fitsHeader.get(name))
+                self.assertEqual(new_img.wcs.fitsHeader.getScalar(name),
+                                 gs_img.wcs.fitsHeader.getScalar(name))
 
 
 class GetStampBoundsTestCase(unittest.TestCase):

--- a/tests/testGalSimInterface.py
+++ b/tests/testGalSimInterface.py
@@ -1250,7 +1250,7 @@ class HourAngleTestCase(unittest.TestCase):
         obs_md.OpsimMetaData['FWHMeff'] = (FWHMgeom - 0.052)/0.822
         obs_md.OpsimMetaData['altitude'] = altitude
         obs_md.OpsimMetaData['rawSeeing'] = seeing
-        gs_interpreter = make_gs_interpreter(obs_md, ['R:2,2 S:1,1'],
+        gs_interpreter = make_gs_interpreter(obs_md, [],
                                              BandpassDict.loadTotalBandpassesFromFiles(),
                                              None, apply_sensor_model=False)
 

--- a/tests/testGalSimInterface.py
+++ b/tests/testGalSimInterface.py
@@ -15,6 +15,7 @@ import lsst.utils
 import lsst.utils.tests
 from lsst.utils import getPackageDir
 import lsst.afw.cameraGeom.testUtils as camTestUtils
+from lsst.sims.photUtils import BandpassDict
 from lsst.sims.utils.CodeUtilities import sims_clean_up
 from lsst.sims.utils import radiansFromArcsec
 from lsst.sims.photUtils import Bandpass, calcSkyCountsPerPixelForM5, LSSTdefaults, PhotometricParameters
@@ -1139,7 +1140,8 @@ class GetStampBoundsTestCase(unittest.TestCase):
         obs_md.OpsimMetaData['FWHMeff'] = (FWHMgeom - 0.052)/0.822
         obs_md.OpsimMetaData['altitude'] = altitude
         obs_md.OpsimMetaData['rawSeeing'] = seeing
-        gs_interpreter = make_gs_interpreter(obs_md, ['R:2,2 S:1,1'], None,
+        gs_interpreter = make_gs_interpreter(obs_md, ['R:2,2 S:1,1'],
+                                             BandpassDict.loadTotalBandpassesFromFiles(),
                                              None, apply_sensor_model=True)
 
         gsobject = GalSimCelestialObject('pointSource', 0, 0, 1e-7, 1e-7, 1e-7,
@@ -1242,7 +1244,8 @@ class HourAngleTestCase(unittest.TestCase):
         obs_md.OpsimMetaData['FWHMeff'] = (FWHMgeom - 0.052)/0.822
         obs_md.OpsimMetaData['altitude'] = altitude
         obs_md.OpsimMetaData['rawSeeing'] = seeing
-        gs_interpreter = make_gs_interpreter(obs_md, ['R:2,2 S:1,1'], None,
+        gs_interpreter = make_gs_interpreter(obs_md, ['R:2,2 S:1,1'],
+                                             BandpassDict.loadTotalBandpassesFromFiles(),
                                              None, apply_sensor_model=True)
 
         mjd = 59877.15107861111027887

--- a/tests/testGalSimInterface.py
+++ b/tests/testGalSimInterface.py
@@ -28,11 +28,13 @@ from lsst.sims.GalSimInterface import (GalSimGalaxies, GalSimStars, GalSimAgn,
                                        GalSimInterpreter, GalSimCameraWrapper,
                                        make_galsim_detector,
                                        make_gs_interpreter,
-                                       GalSimCelestialObject)
+                                       GalSimCelestialObject,
+                                       LSSTCameraWrapper)
 from lsst.sims.GalSimInterface.galSimInterpreter import getGoodPhotImageSize
 from lsst.sims.catUtils.utils import (calcADUwrapper, testGalaxyBulgeDBObj, testGalaxyDiskDBObj,
                                       testGalaxyAgnDBObj, testStarsDBObj)
 import lsst.afw.image as afwImage
+from lsst.sims.coordUtils import clean_up_lsst_camera
 
 ROOT = os.path.abspath(os.path.dirname(__file__))
 
@@ -1120,6 +1122,7 @@ class GetStampBoundsTestCase(unittest.TestCase):
         self.db_name = os.path.join(self.scratch_dir, 'galsim_test_db')
 
     def tearDown(self):
+        clean_up_lsst_camera()
         if os.path.exists(self.db_name):
             os.remove(self.db_name)
         if os.path.exists(self.scratch_dir):
@@ -1140,7 +1143,10 @@ class GetStampBoundsTestCase(unittest.TestCase):
         obs_md.OpsimMetaData['FWHMeff'] = (FWHMgeom - 0.052)/0.822
         obs_md.OpsimMetaData['altitude'] = altitude
         obs_md.OpsimMetaData['rawSeeing'] = seeing
-        gs_interpreter = make_gs_interpreter(obs_md, ['R:2,2 S:1,1'],
+        camera_wrapper = LSSTCameraWrapper()
+        detector = make_galsim_detector(camera_wrapper, 'R:2,2 S:1,1',
+                                        PhotometricParameters(), obs_md)
+        gs_interpreter = make_gs_interpreter(obs_md, [detector],
                                              BandpassDict.loadTotalBandpassesFromFiles(),
                                              None, apply_sensor_model=True)
 

--- a/tests/testGalSimInterface.py
+++ b/tests/testGalSimInterface.py
@@ -1246,7 +1246,7 @@ class HourAngleTestCase(unittest.TestCase):
         obs_md.OpsimMetaData['rawSeeing'] = seeing
         gs_interpreter = make_gs_interpreter(obs_md, ['R:2,2 S:1,1'],
                                              BandpassDict.loadTotalBandpassesFromFiles(),
-                                             None, apply_sensor_model=True)
+                                             None, apply_sensor_model=False)
 
         mjd = 59877.15107861111027887
         ra = 55.52107440528638449


### PR DESCRIPTION
There were some broken unit tests.  This fixes them.

It also replaces `fitsHeader.get()` with `fitsHeader.getScalar()` (which was provoking a `DeprecationWarning`)

Obviously, this is *not* a high priority (but broken unit tests will prevent me from issuing a new `lsst_sims` release when the time comes).