### PR TITLE
Simplify draw procedure for very faint objects

### DIFF
--- a/python/lsst/sims/GalSimInterface/galSimDetector.py
+++ b/python/lsst/sims/GalSimInterface/galSimDetector.py
@@ -1,6 +1,7 @@
 from builtins import zip
 from builtins import object
 import re
+import copy
 from collections import namedtuple
 import galsim
 import numpy as np
@@ -164,6 +165,7 @@ class GalSim_afw_TanSipWCS(galsim.wcs.CelestialWCS):
         _newWcs.__dict__.update(self.__dict__)
         _newWcs.crpix1 = origin.x
         _newWcs.crpix2 = origin.y
+        _newWcs.fitsHeader = copy.deepcopy(self.fitsHeader)
         _newWcs.fitsHeader.set('CRPIX1', origin.x)
         _newWcs.fitsHeader.set('CRPIX2', origin.y)
         return _newWcs

--- a/python/lsst/sims/GalSimInterface/galSimDetector.py
+++ b/python/lsst/sims/GalSimInterface/galSimDetector.py
@@ -160,8 +160,8 @@ class GalSim_afw_TanSipWCS(galsim.wcs.CelestialWCS):
         @param [out] _newWcs is a WCS identical to self, but with the origin
         in pixel space moved to the specified origin
         """
-        _newWcs = GalSim_afw_TanSipWCS(self.detectorName, self.cameraWrapper, self.obs_metadata, self.epoch,
-                                       photParams=self.photParams, wcs=self._tanSipWcs)
+        _newWcs = GalSim_afw_TanSipWCS.__new__(GalSim_afw_TanSipWCS)
+        _newWcs.__dict__.update(self.__dict__)
         _newWcs.crpix1 = origin.x
         _newWcs.crpix2 = origin.y
         _newWcs.fitsHeader.set('CRPIX1', origin.x)

--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -96,12 +96,6 @@ class GalSimInterpreter(object):
         self.centroid_list = []  # This is a list of the centroid objects which
                                  # will be written to the file.
 
-        # Make a trivial SED to use for faint things.
-        blue_limit = np.min([bp.blue_limit for bp in self.gs_bandpass_dict.values()])
-        red_limit = np.max([bp.red_limit for bp in self.gs_bandpass_dict.values()])
-        constant_func = galsim.LookupTable([blue_limit, red_limit], [1,1], interpolant='linear')
-        self.trivial_sed = galsim.SED(constant_func, wave_type='nm', flux_type='fphotons')
-
     def setPSF(self, PSF=None):
         """
         Set the PSF wrapper for this GalSimInterpreter
@@ -722,6 +716,12 @@ class GalSimSiliconInterpeter(GalSimInterpreter):
             = self.getHourAngle(self.obs_metadata.mjd.TAI,
                                 self.obs_metadata.pointingRA)*galsim.degrees
         self.obs_latitude = self.observatory.getLatitude().asDegrees()*galsim.degrees
+
+        # Make a trivial SED to use for faint things.
+        blue_limit = np.min([bp.blue_limit for bp in self.gs_bandpass_dict.values()])
+        red_limit = np.max([bp.red_limit for bp in self.gs_bandpass_dict.values()])
+        constant_func = galsim.LookupTable([blue_limit, red_limit], [1,1], interpolant='linear')
+        self.trivial_sed = galsim.SED(constant_func, wave_type='nm', flux_type='fphotons')
 
         # Create SiliconSensor objects for each detector.
         self.sensor = dict()

--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -241,7 +241,7 @@ class GalSimInterpreter(object):
             self.blankImageCache[detector.name] = image
             return image.copy()
 
-    def drawObject(self, gsObject, max_flux_simple=100, sensor_limit=200):
+    def drawObject(self, gsObject, max_flux_simple=100, sensor_limit=0):
         """
         Draw an astronomical object on all of the relevant FITS files.
 
@@ -736,7 +736,7 @@ class GalSimSiliconInterpeter(GalSimInterpreter):
                                        treering_func=det.tree_rings.func,
                                        transpose=True)
 
-    def drawObject(self, gsObject, max_flux_simple=100, sensor_limit=200):
+    def drawObject(self, gsObject, max_flux_simple=100, sensor_limit=0):
         """
         Draw an astronomical object on all of the relevant FITS files.
 
@@ -751,7 +751,7 @@ class GalSimSiliconInterpeter(GalSimInterpreter):
         @param [in] sensor_limit is the limiting value of the existing flux in the
         postage stamp image, above which the use of a SiliconSensor model is forced.
         For faint things, if there is not already flux at this level, then a simple
-        sensor model will be used instead.  (default = 200)
+        sensor model will be used instead.  (default = 0)
 
         @param [out] outputString is a string denoting which detectors the astronomical
         object illumines, suitable for output in the GalSim InstanceCatalog
@@ -856,7 +856,7 @@ class GalSimSiliconInterpeter(GalSimInterpreter):
                     # For faint things, only use the silicon sensor if there is already
                     # some significant flux on the image near the object.
                     # Brighter-fatter doesn't start having any measurable effect until at least
-                    # around 1000 e-/pixel. So this limit of 200 is conservative by a factor of 5.
+                    # around 1000 e-/pixel. So a limit of 200 is conservative by a factor of 5.
                     # Do the calculation relative to the median, since a perfectly flat sky level
                     # will not have any B/F effect.  (But noise fluctuations due to the sky will
                     # be properly included here if the sky is drawn first.)

--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -241,7 +241,7 @@ class GalSimInterpreter(object):
             self.blankImageCache[detector.name] = image
             return image.copy()
 
-    def drawObject(self, gsObject, max_flux_simple=100, sensor_limit=0):
+    def drawObject(self, gsObject, max_flux_simple=0, sensor_limit=0):
         """
         Draw an astronomical object on all of the relevant FITS files.
 
@@ -249,9 +249,9 @@ class GalSimInterpreter(object):
         class carrying all of the information for the object whose image
         is to be drawn
 
-        @param [in] max_flux_simple is ignored here.
+        @param [in] max_flux_simple is ignored here. (Used by GalSimSiliconInterpreter)
 
-        @param [in] sensor_limit is ignored here.
+        @param [in] sensor_limit is ignored here.  (Used by GalSimSiliconInterpreter)
 
         @param [out] outputString is a string denoting which detectors the astronomical
         object illumines, suitable for output in the GalSim InstanceCatalog
@@ -736,7 +736,7 @@ class GalSimSiliconInterpeter(GalSimInterpreter):
                                        treering_func=det.tree_rings.func,
                                        transpose=True)
 
-    def drawObject(self, gsObject, max_flux_simple=100, sensor_limit=0):
+    def drawObject(self, gsObject, max_flux_simple=0, sensor_limit=0):
         """
         Draw an astronomical object on all of the relevant FITS files.
 
@@ -746,7 +746,7 @@ class GalSimSiliconInterpeter(GalSimInterpreter):
 
         @param [in] max_flux_simple is the maximum flux at which various simplifying
         approximations are used.  These include using a flat SED and possibly omitting
-        the realistic sensor effects. (default = 100)
+        the realistic sensor effects. (default = 0, which means always use the full SED)
 
         @param [in] sensor_limit is the limiting value of the existing flux in the
         postage stamp image, above which the use of a SiliconSensor model is forced.

--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -241,13 +241,17 @@ class GalSimInterpreter(object):
             self.blankImageCache[detector.name] = image
             return image.copy()
 
-    def drawObject(self, gsObject):
+    def drawObject(self, gsObject, max_flux_simple=100, sensor_limit=200):
         """
         Draw an astronomical object on all of the relevant FITS files.
 
         @param [in] gsObject is an instantiation of the GalSimCelestialObject
         class carrying all of the information for the object whose image
         is to be drawn
+
+        @param [in] max_flux_simple is ignored here.
+
+        @param [in] sensor_limit is ignored here.
 
         @param [out] outputString is a string denoting which detectors the astronomical
         object illumines, suitable for output in the GalSim InstanceCatalog

--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -96,6 +96,12 @@ class GalSimInterpreter(object):
         self.centroid_list = []  # This is a list of the centroid objects which
                                  # will be written to the file.
 
+        # Make a trivial SED to use for faint things.
+        blue_limit = np.min([bp.blue_limit for bp in self.gs_bandpass_dict.values()])
+        red_limit = np.max([bp.red_limit for bp in self.gs_bandpass_dict.values()])
+        constant_func = galsim.LookupTable([blue_limit, red_limit], [1,1], interpolant='linear')
+        self.trivial_sed = galsim.SED(constant_func, wave_type='nm', flux_type='fphotons')
+
     def setPSF(self, PSF=None):
         """
         Set the PSF wrapper for this GalSimInterpreter
@@ -778,7 +784,7 @@ class GalSimSiliconInterpeter(GalSimInterpreter):
             # For faint things, use a very simple SED, since we don't really care about getting
             # the exact right distribution of wavelengths here.  (Impacts DCR and electron
             # conversion depth in silicon)
-            gs_sed = galsim.SED('1', wave_type='nm', flux_type='fphotons')
+            gs_sed = self.trivial_sed
         else:
             sed_lut = galsim.LookupTable(x=gsObject.sed.wavelen,
                                          f=gsObject.sed.flambda)

--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -745,13 +745,14 @@ class GalSimSiliconInterpeter(GalSimInterpreter):
         is to be drawn
 
         @param [in] max_flux_simple is the maximum flux at which various simplifying
-        approximations are used.  These include using a flat SED and omitting the
-        realistic sensor effects. (default = 100)
+        approximations are used.  These include using a flat SED and possibly omitting
+        the realistic sensor effects. (default = 100)
 
         @param [in] sensor_limit is the limiting value of the existing flux in the
         postage stamp image, above which the use of a SiliconSensor model is forced.
         For faint things, if there is not already flux at this level, then a simple
-        sensor model will be used instead.  (default = 0)
+        sensor model will be used instead.  (default = 0, which means the SiliconSensor
+        is always used, even for the faint things)
 
         @param [out] outputString is a string denoting which detectors the astronomical
         object illumines, suitable for output in the GalSim InstanceCatalog

--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -720,7 +720,7 @@ class GalSimSiliconInterpeter(GalSimInterpreter):
                                        treering_func=det.tree_rings.func,
                                        transpose=True)
 
-    def drawObject(self, gsObject, max_flux_simple=100):
+    def drawObject(self, gsObject, max_flux_simple=100, sensor_limit=200):
         """
         Draw an astronomical object on all of the relevant FITS files.
 
@@ -731,6 +731,11 @@ class GalSimSiliconInterpeter(GalSimInterpreter):
         @param [in] max_flux_simple is the maximum flux at which various simplifying
         approximations are used.  These include using a flat SED and omitting the
         realistic sensor effects. (default = 100)
+
+        @param [in] sensor_limit is the limiting value of the existing flux in the
+        postage stamp image, above which the use of a SiliconSensor model is forced.
+        For faint things, if there is not already flux at this level, then a simple
+        sensor model will be used instead.  (default = 200)
 
         @param [out] outputString is a string denoting which detectors the astronomical
         object illumines, suitable for output in the GalSim InstanceCatalog
@@ -842,7 +847,7 @@ class GalSimSiliconInterpeter(GalSimInterpreter):
                     # Do the calculation relative to the median, since a perfectly flat sky level
                     # will not have any B/F effect.  (But noise fluctuations due to the sky will
                     # be properly included here if the sky is drawn first.)
-                    if np.max(image.array) > np.median(image.array) + 200:
+                    if np.max(image.array) > np.median(image.array) + sensor_limit:
                         sensor = self.sensor[detector.name]
                     else:
                         sensor = None


### PR DESCRIPTION
This PR implements a proposal I made [here](https://github.com/LSSTDESC/imSim/issues/145#issuecomment-428314743) to simplify the draw procedure for very faint things.  

For the objects that are only going to have of order a 100 photons or less, we mostly just care that the flux is there.  Not that they have a realistic wavelength spectrum and careful treatment of sensor effects that we care about for brighter objects that will actually be used for science.

There are two tunable parameters that we can play with to trade fidelity vs speed:
1. `max_flux_simple` is the maximum flux (in any band) we allow for objects that will get these simplifications.  Default = 100
2. `sensor_limit` is the minimum fluctuation already existing in the image that would force the use of the full SiliconSensor model.  Default = 200

Only if the flux is less than `max_flux_simple` and there aren't any pixels yet above `sensor_limit` do we turn off the sensor effects.  

But the SED is simplified either way if the flux is less than `max_flux_simple`, since that only impacts very subtle things like the exact shape of the DCR effect and the depth distribution of the converted electrons in the silicon.