### PR TITLE
Switch to FFT rendering for bright (saturated) objects

### DIFF
--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -945,6 +945,9 @@ class GalSimSiliconInterpeter(GalSimInterpreter):
         galsim.GSObj, bool: obj = the object to actually use
                             use_fft = whether to use fft drawing
         """
+        if not fft_sb_thresh:
+            return obj, False
+
         # obj.original should be a Convolution with the PSF at the end.  Extract it.
         geom_psf = obj.original.obj_list[-1]
         all_but_psf = obj.original.obj_list[:-1]

--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -887,15 +887,15 @@ class GalSimSiliconInterpeter(GalSimInterpreter):
                     surface_ops = [waves, dcr]
 
                 if use_fft:
-                    obj.drawImage(method='fft',
-                                  offset=offset,
-                                  image=image,
-                                  sensor=sensor,
-                                  surface_ops=surface_ops,
-                                  add_to_image=True,
-                                  gain=detector.photParams.gain)
-                    image.array[image.array < 0] = 0.
-                    image.addNoise(galsim.PoissonNoise())
+                    im1 = obj.drawImage(method='fft',
+                                        offset=offset,
+                                        image=image.copy(),
+                                        sensor=sensor,
+                                        surface_ops=surface_ops,
+                                        gain=detector.photParams.gain)
+                    im1.array[im1.array < 0] = 0.
+                    im1.addNoise(galsim.PoissonNoise())
+                    image += im1
                 else:
                     obj.drawImage(method='phot',
                                   offset=offset,

--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -927,6 +927,10 @@ class GalSimSiliconInterpeter(GalSimInterpreter):
         should only be done when the core is going to be saturated anyway, so we only really
         care about the wings of the PSF.
 
+        Note: This function assumes that obj at this point is a convolution with the PSF at the
+              end, and that it has had its flux set to a new value with `withFlux()`.
+              If this is not the case, an AttributeError will be raised.
+
         Parameters
         ----------
         gsObject: GalSimCelestialObject

--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -980,7 +980,7 @@ class GalSimSiliconInterpeter(GalSimInterpreter):
                 fft_psf = [optical_psf]
             else:
                 fft_psf = []
-            r0_500 = geom_psf.r0_500_effective
+            r0_500 = screen_list.r0_500_effective
             atm_psf = galsim.Kolmogorov(lam=geom_psf.lam, r0_500=r0_500,
                                         gsparams=geom_psf.gsparams)
             fft_psf.append(atm_psf)

--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -730,7 +730,7 @@ class GalSimSiliconInterpeter(GalSimInterpreter):
                                        treering_func=det.tree_rings.func,
                                        transpose=True)
 
-    def drawObject(self, gsObject, max_flux_simple=0, sensor_limit=0, fft_sb_thresh=0):
+    def drawObject(self, gsObject, max_flux_simple=0, sensor_limit=0, fft_sb_thresh=None):
         """
         Draw an astronomical object on all of the relevant FITS files.
 
@@ -750,7 +750,7 @@ class GalSimSiliconInterpeter(GalSimInterpreter):
 
         @param [in] fft_sb_thresh is a surface brightness (photons/pixel) where we will
         switch from photon shooting to drawing with fft if any pixel is above this.
-        Should be at least the saturation level, if not higher. (default = 0, which means
+        Should be at least the saturation level, if not higher. (default = None, which means
         never switch to fft.)
 
         @param [out] outputString is a string denoting which detectors the astronomical
@@ -821,7 +821,7 @@ class GalSimSiliconInterpeter(GalSimInterpreter):
             obj = centeredObj.withFlux(realized_flux)
 
             use_fft = False
-            if realized_flux > 1.e6 and fft_sb_thesh > 0 and realized_flux > thresh:
+            if realized_flux > 1.e6 and fft_sb_thesh is not None and realized_flux > thresh:
                 # Note: Don't bother with this check unless the total flux is > thresh.
                 # Otherwise, there is no chance that the flux in 1 pixel is > thresh.
                 # Also, the cross-over point for time to where the fft becomes faster is

--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -823,7 +823,7 @@ class GalSimSiliconInterpeter(GalSimInterpreter):
             obj = centeredObj.withFlux(realized_flux)
 
             use_fft = False
-            if realized_flux > 1.e6 and fft_sb_thesh is not None and realized_flux > thresh:
+            if realized_flux > 1.e6 and fft_sb_thresh is not None and realized_flux > fft_sb_thresh:
                 # Note: Don't bother with this check unless the total flux is > thresh.
                 # Otherwise, there is no chance that the flux in 1 pixel is > thresh.
                 # Also, the cross-over point for time to where the fft becomes faster is

--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -240,7 +240,7 @@ class GalSimInterpreter(object):
             self.blankImageCache[detector.name] = image
             return image.copy()
 
-    def drawObject(self, gsObject, max_flux_simple=0, sensor_limit=0):
+    def drawObject(self, gsObject, max_flux_simple=0, sensor_limit=0, fft_sb_thresh=None):
         """
         Draw an astronomical object on all of the relevant FITS files.
 
@@ -251,6 +251,8 @@ class GalSimInterpreter(object):
         @param [in] max_flux_simple is ignored here. (Used by GalSimSiliconInterpreter)
 
         @param [in] sensor_limit is ignored here.  (Used by GalSimSiliconInterpreter)
+
+        @param [in] fft_sb_thresh is ignored here.  (Used by GalSimSiliconInterpreter)
 
         @param [out] outputString is a string denoting which detectors the astronomical
         object illumines, suitable for output in the GalSim InstanceCatalog

--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -917,6 +917,7 @@ class GalSimSiliconInterpeter(GalSimInterpreter):
         self.write_checkpoint()
         return outputString
 
+    @staticmethod
     def maybeSwitchPSF(gsObject, obj, fft_sb_thresh, pixel_scale=0.2):
         """
         Check if the maximum surface brightness of the object is high enough that we should

--- a/python/lsst/sims/GalSimInterface/galSimPSF.py
+++ b/python/lsst/sims/GalSimInterface/galSimPSF.py
@@ -68,13 +68,12 @@ class PSFbase(object):
         #coordinates and (optionally) wavelength
         psf = self._getPSF(xPupil=xPupil, yPupil=yPupil, **kwargs)
 
-        if obj is not None:
-            #if we are dealing with an extended object, convolve it with the psf
-            obj = galsim.Convolve(obj, psf)
-            return obj
-        else:
-            #if there is no object (i.e. if this is a point source), just return the PSF
-            return psf
+        if obj is None:
+            #if there is no object, use a DeltaFunction as a point source
+            obj = galsim.DeltaFunction()
+
+        #convolve obj with the psf
+        return galsim.Convolve(obj, psf)
 
     def __eq__(self, rhs):
         """


### PR DESCRIPTION
This PR implements [ImSim issue 157](https://github.com/LSSTDESC/imSim/issues/157) to transition to using FFT rendering when the object is very bright.  

It's not really efficient to do this with the full atmospheric screen PSF, but if the object is saturated, we don't really care about the central turbulent part being right.  Rather, we mostly just care that the wings are more or less correct.  So this implements transitioning to a Kolmogorov convolved with an OpticalPSF taking all the relevant parameters from the currently active PhaseScreenPSF.  So it matches the regular PSF as much as possible.

The FFT rendering time maxes out at around 1 second (on my laptop) for any flux, and the transition seems to be around 1e6 photons.  Since 1e6 photons is not typically saturated, I set it up to keep using the regular photon shooting rendering until the object would be saturated and switch over at that point.

The recommended way to use this is to set fft_sb_thresh to the saturation value, 1.e5, or possibly a bit higher to be conservative.  The default value is None, which means don't ever switch.

As usual, I didn't try to run this, since I don't have an easy way to do so.  But I did run some tests of the salient bits of code on my laptop to try it out.  So apologies in advance if there are any stupid coding errors here.