### PR TITLE
Don't use sensor in fft mode

### DIFF
--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -874,6 +874,7 @@ class GalSimSiliconInterpreter(GalSimInterpreter):
 
             if use_fft:
                 object_flags.set_flag('fft_rendered')
+                object_flags.set_flag('no_silicon')
 
             for detector in detectorList:
 
@@ -935,8 +936,6 @@ class GalSimSiliconInterpreter(GalSimInterpreter):
                     im1 = obj.drawImage(method='fft',
                                         offset=offset,
                                         image=image.copy(),
-                                        sensor=sensor,
-                                        surface_ops=surface_ops,
                                         gain=detector.photParams.gain)
                     im1.array[im1.array < 0] = 0.
                     im1.addNoise(galsim.PoissonNoise())


### PR DESCRIPTION
Jim found that bright stars that switch to FFT mode use a horrendous amount of memory and take forever.  This is because they are still doing photon shooting through the silicon sensor, which defeats the whole point of switching over to FFT rendering.

This PR just turns off the sensor whenever we have decided to switch to FFT mode.