### PR TITLE
Refactor maybeSwitchPSF a bit for speed

### DIFF
--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -866,7 +866,8 @@ class GalSimSiliconInterpreter(GalSimInterpreter):
             # For very bright things, we might want to switch to FFT rendering, in which case
             # the PSF needs to be swapped out for something similar but without all the
             # atmospheric screens.
-            obj, use_fft = self.maybeSwitchPSF(gsObject, obj, fft_sb_thresh)
+            if fft_sb_thresh and realized_flux > 1.e6:
+                obj, use_fft = self.maybeSwitchPSF(gsObject, obj, fft_sb_thresh)
 
             if use_fft:
                 object_flags.set_flag('fft_rendered')
@@ -1004,7 +1005,7 @@ class GalSimSiliconInterpreter(GalSimInterpreter):
         # Also, the cross-over point for time to where the fft becomes faster is
         # emprically around 1.e6 photons, so also don't bother unless the flux
         # is more than this.
-        if realized_flux < fft_sb_thresh or  realized_flux < 1.e6:
+        if realized_flux < fft_sb_thresh or realized_flux < 1.e6:
             return obj, False
 
         # obj.original should be a Convolution with the PSF at the end.  Extract it.


### PR DESCRIPTION
There was a hypothesis about a reason for some inefficiency in the current 2.1i run that some code in `maybeSwitchPSF` was inefficiency.  I'm pretty sure this was a red herring, since the function only got called a handful of times (only when the flux was > 1.e6).  

But since I had already started coding it up, I figured I'd go ahead an make a PR for it.

The two salient changes are:
1. Grab the Aperture from the geometric screen rather than make a new one when building the `OpticalPSF`, so it doesn't have to recalculate the pupil plane image.
2. Add an additional early exit that just checks the Kolmogorov max sb, since that should always be very quick to calculate.  And if that peak is < thresh, then there is no point continuing on to put the object back together and check the full thing.