### PR TITLE
Don't use xValue on profiles with a RandomWalk component

### DIFF
--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -1170,6 +1170,16 @@ def getGoodPhotImageSize(obj, keep_sb_level, pixel_scale=0.2):
     N = obj.getGoodImageSize(pixel_scale)
     #print('N = ',N)
 
+    try:
+        # If the galaxy is a RandomWalk, extract the underlying profile for this calculation
+        # rather than using the knotty version, which will pose problems for the xValue function.
+        gal = obj.original.obj_list[0]
+        gal = galsim.Transformation(gal.original._profile,
+                gal.jac, gal.offset, gal.flux_ratio, gal.gsparams)
+        obj = galsim.Convolve(gal, *obj.original.obj_list[1:]) * obj.flux_ratio
+    except Exception:
+        pass
+
     # This can be too small for bright stars, so increase it in steps until the edges are
     # all below the requested sb level.
     # (Don't go bigger than 4096)

--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -1178,6 +1178,9 @@ def getGoodPhotImageSize(obj, keep_sb_level, pixel_scale=0.2):
                 gal.jac, gal.offset, gal.flux_ratio, gal.gsparams)
         obj = galsim.Convolve(gal, *obj.original.obj_list[1:]) * obj.flux_ratio
     except Exception:
+        # If not a RandomWalk, then `._profile` will raise an AttributeError.
+        # Catch any (non-Base) Exception though in case there are other possibilities
+        # I didn't anticipate, where we should just leave the obj alone.
         pass
 
     # This can be too small for bright stars, so increase it in steps until the edges are


### PR DESCRIPTION
RandomWalk galaxies in GalSim shouldn't be used with real-space convolution.  This was inadvertently being done in `getGoodPhotImageSize` to find a good stamp size for these objects.  To avoid this, this PR pulls out the underlying profile and uses that instead of the knotty version, which should produce a good estimate of the stamp size required for the original object.