### PR TITLE
switch back to photon shooting if FFT size is too large

### DIFF
--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -950,7 +950,7 @@ class GalSimSiliconInterpreter(GalSimInterpreter):
                     try:
                         obj.drawImage(method='fft',
                                       offset=fft_offset,
-                                      image=fft_image
+                                      image=fft_image,
                                       gain=detector.photParams.gain)
                     except galsim.errors.GalSimFFTSizeError:
                         use_fft = False

--- a/tests/testObjectFlags.py
+++ b/tests/testObjectFlags.py
@@ -1,0 +1,28 @@
+"""
+Test code for ObjectFlags class.
+"""
+from collections import OrderedDict
+import unittest
+from lsst.sims.GalSimInterface import ObjectFlags
+
+class ObjectFlagsTestCase(unittest.TestCase):
+    """Test case class for ObjectFlags."""
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_ObjectFlags(self):
+        """Unit test for ObjectFlags class."""
+        conditions = OrderedDict([(condition, index) for index, condition
+                                  in enumerate('abcde')])
+        flags = ObjectFlags(conditions=list(conditions.keys()))
+        for condition, index in conditions.items():
+            flags.set_flag(condition)
+            self.assertEqual(2**index, flags.value)
+            flags.unset_flag(condition)
+            self.assertEqual(0, flags.value)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
add `ObjectFlags.unset_flag` method to update the rendering info