### PR TITLE
use the seeded rng for adding PoissonNoise to the fft-rendered objects

### DIFF
--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -964,7 +964,7 @@ class GalSimSiliconInterpreter(GalSimInterpreter):
                     else:
                         # Some pixels can end up negative from FFT numerics.  Just set them to 0.
                         fft_image.array[fft_image.array < 0] = 0.
-                        fft_image.addNoise(galsim.PoissonNoise())
+                        fft_image.addNoise(galsim.PoissonNoise(rng=self._rng))
                         # In case we had to make a bigger image, just copy the part we need.
                         image += fft_image[bounds]
                 if not use_fft:


### PR DESCRIPTION
This is needed to ensure that imsim images for the same sensor visit using the same seed are pixel-wise identical for different runs.