### PR TITLE
silence afw.geom deprecation warnings

### DIFF
--- a/python/lsst/sims/GalSimInterface/galSimCameraWrapper.py
+++ b/python/lsst/sims/GalSimInterface/galSimCameraWrapper.py
@@ -58,7 +58,7 @@ need:
 import numpy as np
 from lsst.afw.cameraGeom import FOCAL_PLANE, PIXELS, TAN_PIXELS
 from lsst.afw.cameraGeom import FIELD_ANGLE
-import lsst.afw.geom as afwGeom
+import lsst.geom as LsstGeom
 import lsst.sims.coordUtils as coordUtils
 import lsst.sims.utils as simsUtils
 
@@ -113,7 +113,7 @@ class GalSimCameraWrapper(object):
     def getCenterPupil(self, detector_name):
         """
         Return the pupil coordinates of the center of the named detector
-        as an afwGeom.Point2D
+        as an LsstGeom.Point2D
         """
         if not hasattr(self, '_center_pupil_cache'):
             self._center_pupil_cache = {}
@@ -129,7 +129,7 @@ class GalSimCameraWrapper(object):
     def getCornerPupilList(self, detector_name):
         """
         Return a list of the pupil coordinates of the corners of the named
-        detector as a list of afwGeom.Point2D objects
+        detector as a list of LsstGeom.Point2D objects
         """
         if not hasattr(self, '_corner_pupil_cache'):
             self._corner_pupil_cache = {}

--- a/python/lsst/sims/GalSimInterface/galSimCatalogs.py
+++ b/python/lsst/sims/GalSimInterface/galSimCatalogs.py
@@ -28,7 +28,7 @@ from lsst.sims.GalSimInterface import make_galsim_detector
 from lsst.sims.photUtils import (Sed, Bandpass, BandpassDict,
                                  PhotometricParameters)
 import lsst.afw.cameraGeom.testUtils as camTestUtils
-import lsst.afw.geom as afwGeom
+import lsst.geom as LsstGeom
 from lsst.afw.cameraGeom import FIELD_ANGLE, PIXELS, FOCAL_PLANE
 from lsst.afw.cameraGeom import WAVEFRONT, GUIDER
 

--- a/python/lsst/sims/GalSimInterface/galSimDetector.py
+++ b/python/lsst/sims/GalSimInterface/galSimDetector.py
@@ -9,7 +9,7 @@ import astropy.coordinates
 from astropy._erfa import ErfaWarning
 import galsim
 import numpy as np
-import lsst.afw.geom as afwGeom
+import lsst.geom as LsstGeom
 from lsst.afw.cameraGeom import FIELD_ANGLE, PIXELS, FOCAL_PLANE
 from lsst.afw.cameraGeom import WAVEFRONT, GUIDER
 from lsst.obs.lsstSim import LsstSimMapper
@@ -23,7 +23,7 @@ __all__ = ["GalSimDetector", "make_galsim_detector", "LsstObservatory"]
 
 class GalSim_afw_TanSipWCS(galsim.wcs.CelestialWCS):
     """
-    This class uses methods from afw.geom and meas_astrom to
+    This class uses methods from lsst.geom and meas_astrom to
     fit a TAN-SIP WCS to an afw.cameraGeom.Detector and then wrap
     that WCS into something that GalSim can parse.
 
@@ -264,7 +264,7 @@ class GalSimDetector(object):
         self._yMinPix = bbox.getMinY()
         self._yMaxPix = bbox.getMaxY()
 
-        self._bbox = afwGeom.Box2D(bbox)
+        self._bbox = LsstGeom.Box2D(bbox)
 
         centerPupil = self._cameraWrapper.getCenterPupil(self._name)
         self._xCenterArcsec = arcsecFromRadians(centerPupil.getX())
@@ -374,7 +374,7 @@ class GalSimDetector(object):
         """
 
         xPix, yPix = self.pixelCoordinatesFromRaDec(ra, dec)
-        points = [afwGeom.Point2D(xx, yy) for xx, yy in zip(xPix, yPix)]
+        points = [LsstGeom.Point2D(xx, yy) for xx, yy in zip(xPix, yPix)]
         answer = [self._bbox.contains(pp) for pp in points]
         return answer
 
@@ -392,7 +392,7 @@ class GalSimDetector(object):
         the corresponding RA, Dec pair falls on this detector
         """
         xPix, yPix = self.pixelCoordinatesFromPupilCoordinates(xPupil, yPupil)
-        points = [afwGeom.Point2D(xx, yy) for xx, yy in zip(xPix, yPix)]
+        points = [LsstGeom.Point2D(xx, yy) for xx, yy in zip(xPix, yPix)]
         answer = [self._bbox.contains(pp) for pp in points]
         return answer
 

--- a/python/lsst/sims/GalSimInterface/wcsUtils/ApproximateWCS.py
+++ b/python/lsst/sims/GalSimInterface/wcsUtils/ApproximateWCS.py
@@ -30,7 +30,6 @@ from builtins import range
 import numpy as np
 import lsst.afw.image as afwImage
 import lsst.afw.table as afwTable
-import lsst.afw.geom as afwGeom
 import lsst.geom as LsstGeom
 from lsst.meas.base import SingleFrameMeasurementTask
 from lsst.meas.astrom.sip import makeCreateWcsWithSip
@@ -40,7 +39,7 @@ __all__ = ["approximateWcs"]
 
 def approximateWcs(wcs, camera_wrapper=None, detector_name=None, obs_metadata=None,
                    order=3, nx=20, ny=20, iterations=3,
-                   skyTolerance=0.001*afwGeom.arcseconds, pixelTolerance=0.02):
+                   skyTolerance=0.001*LsstGeom.arcseconds, pixelTolerance=0.02):
     """Approximate an existing WCS as a TAN-SIP WCS
 
     The fit is performed by evaluating the WCS at a uniform grid of points within a bounding box.
@@ -81,11 +80,11 @@ def approximateWcs(wcs, camera_wrapper=None, detector_name=None, obs_metadata=No
         matchList = []
 
     bbox = camera_wrapper.getBBox(detector_name)
-    bboxd = afwGeom.Box2D(bbox)
+    bboxd = LsstGeom.Box2D(bbox)
 
     for x in np.linspace(bboxd.getMinX(), bboxd.getMaxX(), nx):
         for y in np.linspace(bboxd.getMinY(), bboxd.getMaxY(), ny):
-            pixelPos = afwGeom.Point2D(x, y)
+            pixelPos = LsstGeom.Point2D(x, y)
 
             ra, dec = camera_wrapper.raDecFromPixelCoords(np.array([x]), np.array([y]),
                                                           detector_name,
@@ -93,7 +92,7 @@ def approximateWcs(wcs, camera_wrapper=None, detector_name=None, obs_metadata=No
                                                           epoch=2000.0,
                                                           includeDistortion=True)
 
-            skyCoord = afwGeom.SpherePoint(ra[0], dec[0], LsstGeom.degrees)
+            skyCoord = LsstGeom.SpherePoint(ra[0], dec[0], LsstGeom.degrees)
 
             refObj = refCat.addNew()
             refObj.set(refCoordKey, skyCoord)

--- a/python/lsst/sims/GalSimInterface/wcsUtils/WcsUtils.py
+++ b/python/lsst/sims/GalSimInterface/wcsUtils/WcsUtils.py
@@ -1,6 +1,7 @@
 import numpy as np
 from lsst.afw.cameraGeom import TAN_PIXELS, FOCAL_PLANE
 import lsst.afw.geom as afwGeom
+import lsst.geom as LsstGeom
 import lsst.afw.image as afwImage
 import lsst.afw.image.utils as afwImageUtils
 import lsst.daf.base as dafBase
@@ -169,7 +170,7 @@ def tanSipWcsFromDetector(detector_name, camera_wrapper, obs_metadata, epoch,
 
     tanSipWcs = approximateWcs(tanWcs,
                                order=order,
-                               skyTolerance=skyToleranceArcSec*afwGeom.arcseconds,
+                               skyTolerance=skyToleranceArcSec*LsstGeom.arcseconds,
                                pixelTolerance=pixelTolerance,
                                detector_name=detector_name,
                                camera_wrapper=camera_wrapper,

--- a/tests/testOutputWcs.py
+++ b/tests/testOutputWcs.py
@@ -7,7 +7,6 @@ import shutil
 import lsst.utils.tests
 from lsst.utils import getPackageDir
 import lsst.afw.image as afwImage
-import lsst.afw.geom as afwGeom
 import lsst.geom as LsstGeom
 from lsst.sims.utils.CodeUtilities import sims_clean_up
 from lsst.sims.utils import ObservationMetaData, arcsecFromRadians
@@ -132,7 +131,7 @@ class GalSimOutputWcsTest(unittest.TestCase):
                     xxTestList.append(xx)
                     yyTestList.append(yy)
 
-                    pt = afwGeom.Point2D(xx, yy)
+                    pt = LsstGeom.Point2D(xx, yy)
                     skyPt = wcs.pixelToSky(pt).getPosition(LsstGeom.degrees)
                     raImage.append(skyPt.getX())
                     decImage.append(skyPt.getY())

--- a/tests/testWcsUtils.py
+++ b/tests/testWcsUtils.py
@@ -2,7 +2,6 @@ import unittest
 import os
 import numpy as np
 import lsst.utils.tests
-import lsst.afw.geom as afwGeom
 import lsst.geom as LsstGeom
 from lsst.utils import getPackageDir
 from lsst.sims.utils.CodeUtilities import sims_clean_up
@@ -76,7 +75,7 @@ class WcsTest(unittest.TestCase):
                 xPixList.append(xx)
                 yPixList.append(yy)
 
-                pt = afwGeom.Point2D(xx, yy)
+                pt = LsstGeom.Point2D(xx, yy)
                 skyPt = tanWcs.pixelToSky(pt).getPosition(LsstGeom.degrees)
                 tanWcsRa.append(skyPt.getX())
                 tanWcsDec.append(skyPt.getY())


### PR DESCRIPTION
Many warnings like
```
self._bbox = afwGeom.Box2D(bbox)
5559/opt/lsst/software/stack/stack/miniconda3-4.5.12-1172c30/Linux64/sims_GalSimInterface/2.13.0.sims-8-gebdc50b+1/python/lsst/sims/GalSimInterface/galSimDetector.py:267: FutureWarning: Call to deprecated function (or staticmethod) Box2D. (Replaced by lsst.geom.Box2D (will be removed before the release of v20.0))
```
are being generated when using `lsst_sims` `w_2019_37`.  This PR will silence them