### PR TITLE
U/danielsf/when obs lsst sim breaks

### DIFF
--- a/python/lsst/sims/GalSimInterface/galSimCameraWrapper.py
+++ b/python/lsst/sims/GalSimInterface/galSimCameraWrapper.py
@@ -56,6 +56,7 @@ need:
 """
 
 import numpy as np
+import lsst.obs.lsst.phosim as obs_lsst_phosim
 from lsst.afw.cameraGeom import FOCAL_PLANE, PIXELS, TAN_PIXELS
 from lsst.afw.cameraGeom import FIELD_ANGLE
 import lsst.geom as LsstGeom
@@ -483,6 +484,11 @@ class GalSimCameraWrapper(object):
 class LSSTCameraWrapper(coordUtils.DMtoCameraPixelTransformer,
                         GalSimCameraWrapper):
 
+    def __init__(self):
+        self._camera = obs_lsst_phosim.PhosimMapper().camera
+
+
+
     def getTanPixelBounds(self, detector_name):
         """
         Return the min and max pixel values of a detector, assuming
@@ -544,10 +550,10 @@ class LSSTCameraWrapper(coordUtils.DMtoCameraPixelTransformer,
         are defined in the Camera team system, rather than the DM system.
         """
         (dm_x_pix,
-         dm_y_pix) = coordUtils.pixelCoordsFromPupilCoordsLSST(xPupil, yPupil,
-                                                               chipName=chipName,
-                                                               band=obs_metadata.bandpass,
-                                                               includeDistortion=includeDistortion)
+         dm_y_pix) = coordUtils.pixelCoordsFromPupilCoords(xPupil, yPupil,
+                                                           chipName=chipName,
+                                                           camera=self.camera,
+                                                           includeDistortion=includeDistortion)
 
         cam_y_pix = dm_x_pix
         if isinstance(chipName, list) or isinstance(chipName, np.ndarray):
@@ -609,9 +615,9 @@ class LSSTCameraWrapper(coordUtils.DMtoCameraPixelTransformer,
         else:
             cam_center_pix = self.getCenterPixel(chipName)
             dm_yPix = 2.0*cam_center_pix.getX()-xPix
-        return coordUtils.pupilCoordsFromPixelCoordsLSST(dm_xPix, dm_yPix, chipName,
-                                                         band=obs_metadata.bandpass,
-                                                         includeDistortion=includeDistortion)
+        return coordUtils.pupilCoordsFromPixelCoords(dm_xPix, dm_yPix, chipName,
+                                                     camera=self.camera,
+                                                     includeDistortion=includeDistortion)
 
     def _raDecFromPixelCoords(self, xPix, yPix, chipName, obs_metadata,
                               epoch=2000.0, includeDistortion=True):
@@ -666,11 +672,11 @@ class LSSTCameraWrapper(coordUtils.DMtoCameraPixelTransformer,
             cam_center_pix = self.getCenterPixel(chipName)
             dm_yPix = 2.0*cam_center_pix.getX() - xPix
 
-        return coordUtils._raDecFromPixelCoordsLSST(dm_xPix, dm_yPix, chipName,
-                                                    obs_metadata=obs_metadata,
-                                                    band=obs_metadata.bandpass,
-                                                    epoch=epoch,
-                                                    includeDistortion=includeDistortion)
+        return coordUtils._raDecFromPixelCoords(dm_xPix, dm_yPix, chipName,
+                                                obs_metadata=obs_metadata,
+                                                camera=self.camera,
+                                                epoch=epoch,
+                                                includeDistortion=includeDistortion)
 
     def raDecFromPixelCoords(self, xPix, yPix, chipName, obs_metadata,
                              epoch=2000.0, includeDistortion=True):
@@ -775,14 +781,14 @@ class LSSTCameraWrapper(coordUtils.DMtoCameraPixelTransformer,
         are defined in the Camera team system, rather than the DM system.
         """
 
-        dm_xPix, dm_yPix =  coordUtils._pixelCoordsFromRaDecLSST(ra, dec,
-                                                                 pm_ra=pm_ra, pm_dec=pm_dec,
-                                                                 parallax=parallax, v_rad=v_rad,
-                                                                 obs_metadata=obs_metadata,
-                                                                 chipName=chipName,
-                                                                 band=obs_metadata.bandpass,
-                                                                 epoch=epoch,
-                                                                 includeDistortion=includeDistortion)
+        dm_xPix, dm_yPix =  coordUtils._pixelCoordsFromRaDec(ra, dec,
+                                                             pm_ra=pm_ra, pm_dec=pm_dec,
+                                                             parallax=parallax, v_rad=v_rad,
+                                                             obs_metadata=obs_metadata,
+                                                             chipName=chipName,
+                                                             camera=self.camera,
+                                                             epoch=epoch,
+                                                             includeDistortion=includeDistortion)
 
         return self.cameraPixFromDMPix(dm_xPix, dm_yPix, chipName)
 

--- a/python/lsst/sims/GalSimInterface/galSimDetector.py
+++ b/python/lsst/sims/GalSimInterface/galSimDetector.py
@@ -10,9 +10,9 @@ from astropy._erfa import ErfaWarning
 import galsim
 import numpy as np
 import lsst.geom as LsstGeom
+import lsst.obs.lsst.translators.lsst
 from lsst.afw.cameraGeom import FIELD_ANGLE, PIXELS, FOCAL_PLANE
 from lsst.afw.cameraGeom import WAVEFRONT, GUIDER
-from lsst.obs.lsstSim import LsstSimMapper
 from lsst.sims.utils import arcsecFromRadians
 from lsst.sims.GalSimInterface.wcsUtils import tanSipWcsFromDetector
 from lsst.sims.GalSimInterface import GalSimCameraWrapper
@@ -116,10 +116,10 @@ class GalSim_afw_TanSipWCS(galsim.wcs.CelestialWCS):
         self.fitsHeader.set('SIMULATE', True)
         self.fitsHeader.set('ORIGIN', 'IMSIM')
         observatory = LsstObservatory()
-        self.fitsHeader.set('OBS-LONG', observatory.getLongitude().asDegrees())
-        self.fitsHeader.set('OBS-LAT', observatory.getLongitude().asDegrees())
-        self.fitsHeader.set('OBS-ELEV', observatory.getElevation())
-        obs_location = observatory.getLocation()
+        self.fitsHeader.set('OBS-LONG', observatory.lon.degree)
+        self.fitsHeader.set('OBS-LAT', observatory.lat.degree)
+        self.fitsHeader.set('OBS-ELEV', observatory.height.value)
+        obs_location = observatory.to_geocentric()
         self.fitsHeader.set('OBSGEO-X', obs_location.geocentric[0].value)
         self.fitsHeader.set('OBSGEO-Y', obs_location.geocentric[1].value)
         self.fitsHeader.set('OBSGEO-Z', obs_location.geocentric[2].value)
@@ -688,7 +688,7 @@ class LsstObservatory:
     observatory location information.
     """
     def __init__(self):
-        self.observatory = LsstSimMapper().MakeRawVisitInfoClass().observatory
+        self.observatory = lsst.obs.lsst.translators.lsst.LSST_LOCATION
 
     def getLocation(self):
         """
@@ -698,10 +698,7 @@ class LsstObservatory:
         -------
         astropy.coordinates.earth.EarthLocation
         """
-        return astropy.coordinates.EarthLocation.from_geodetic(
-            self.observatory.getLongitude().asDegrees(),
-            self.observatory.getLatitude().asDegrees(),
-            self.observatory.getElevation())
+        return self.observatory
 
     def __getattr__(self, attr):
         if hasattr(self.observatory, attr):

--- a/python/lsst/sims/GalSimInterface/galSimDetector.py
+++ b/python/lsst/sims/GalSimInterface/galSimDetector.py
@@ -119,10 +119,9 @@ class GalSim_afw_TanSipWCS(galsim.wcs.CelestialWCS):
         self.fitsHeader.set('OBS-LONG', observatory.lon.degree)
         self.fitsHeader.set('OBS-LAT', observatory.lat.degree)
         self.fitsHeader.set('OBS-ELEV', observatory.height.value)
-        obs_location = observatory.to_geocentric()
-        self.fitsHeader.set('OBSGEO-X', obs_location.geocentric[0].value)
-        self.fitsHeader.set('OBSGEO-Y', obs_location.geocentric[1].value)
-        self.fitsHeader.set('OBSGEO-Z', obs_location.geocentric[2].value)
+        self.fitsHeader.set('OBSGEO-X', observatory.geocentric[0].value)
+        self.fitsHeader.set('OBSGEO-Y', observatory.geocentric[1].value)
+        self.fitsHeader.set('OBSGEO-Z', observatory.geocentric[2].value)
 
         self.crpix1 = self.fitsHeader.getScalar("CRPIX1")
         self.crpix2 = self.fitsHeader.getScalar("CRPIX2")
@@ -689,6 +688,7 @@ class LsstObservatory:
     """
     def __init__(self):
         self.observatory = lsst.obs.lsst.translators.lsst.LSST_LOCATION
+        self.geocentric = self.observatory.to_geocentric()
 
     def getLocation(self):
         """

--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -770,7 +770,7 @@ class GalSimSiliconInterpreter(GalSimInterpreter):
         self.local_hour_angle \
             = self.getHourAngle(self.obs_metadata.mjd.TAI,
                                 self.obs_metadata.pointingRA)*galsim.degrees
-        self.obs_latitude = self.observatory.getLatitude().asDegrees()*galsim.degrees
+        self.obs_latitude = self.observatory.lat.degree*galsim.degrees
 
         # Make a trivial SED to use for faint things.
         blue_limit = np.min([bp.blue_limit for bp in self.gs_bandpass_dict.values()])

--- a/tests/testFitsHeaders.py
+++ b/tests/testFitsHeaders.py
@@ -23,7 +23,6 @@ from lsst.sims.coordUtils import pupilCoordsFromFocalPlaneCoordsLSST
 
 from testUtils import create_text_catalog
 
-from lsst.sims.coordUtils import clean_up_lsst_camera
 
 ROOT = os.path.abspath(os.path.dirname(__file__))
 
@@ -67,7 +66,6 @@ class FitsHeaderTest(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         sims_clean_up()
-        clean_up_lsst_camera()
 
     def testFitsHeader(self):
         """

--- a/tests/testGalSimCameraWrapper.py
+++ b/tests/testGalSimCameraWrapper.py
@@ -27,7 +27,6 @@ from lsst.sims.coordUtils import pixelCoordsFromPupilCoordsLSST
 from lsst.sims.coordUtils import raDecFromPixelCoordsLSST
 from lsst.sims.coordUtils import lsst_camera
 
-from lsst.sims.coordUtils import clean_up_lsst_camera
 
 def setup_module(module):
     lsst.utils.tests.init()
@@ -36,10 +35,6 @@ def setup_module(module):
 class Camera_Wrapper_Test_Class(unittest.TestCase):
 
     longMessage = True
-
-    @classmethod
-    def tearDownClass(cls):
-        clean_up_lsst_camera()
 
     def test_generic_camera_wrapper(self):
         """

--- a/tests/testGalSimInterface.py
+++ b/tests/testGalSimInterface.py
@@ -1059,7 +1059,7 @@ class CheckPointingTestCase(unittest.TestCase):
 
         # Set the image data by hand.
         key = "R00_S00_r.fits"
-        detname = "R:0,0 S:0,0"
+        detname = "R00_S00"
         detector = make_galsim_detector(camera_wrapper, detname,
                                         phot_params, obs_md)
         image = gs_interpreter.blankImage(detector=detector)
@@ -1141,7 +1141,7 @@ class GetStampBoundsTestCase(unittest.TestCase):
         obs_md.OpsimMetaData['altitude'] = altitude
         obs_md.OpsimMetaData['rawSeeing'] = seeing
         camera_wrapper = LSSTCameraWrapper()
-        detector = make_galsim_detector(camera_wrapper, 'R:2,2 S:1,1',
+        detector = make_galsim_detector(camera_wrapper, 'R22_S11',
                                         PhotometricParameters(), obs_md)
         gs_interpreter = make_gs_interpreter(obs_md, [detector],
                                              BandpassDict.loadTotalBandpassesFromFiles(),

--- a/tests/testGalSimInterface.py
+++ b/tests/testGalSimInterface.py
@@ -34,7 +34,6 @@ from lsst.sims.GalSimInterface.galSimInterpreter import getGoodPhotImageSize
 from lsst.sims.catUtils.utils import (calcADUwrapper, testGalaxyBulgeDBObj, testGalaxyDiskDBObj,
                                       testGalaxyAgnDBObj, testStarsDBObj)
 import lsst.afw.image as afwImage
-from lsst.sims.coordUtils import clean_up_lsst_camera
 
 # Tell astropy not to download this file again, even if it's out of date.
 from astropy.utils import iers
@@ -1121,7 +1120,6 @@ class GetStampBoundsTestCase(unittest.TestCase):
         self.db_name = os.path.join(self.scratch_dir, 'galsim_test_db')
 
     def tearDown(self):
-        clean_up_lsst_camera()
         if os.path.exists(self.db_name):
             os.remove(self.db_name)
         if os.path.exists(self.scratch_dir):

--- a/tests/testGalSimInterface.py
+++ b/tests/testGalSimInterface.py
@@ -1059,7 +1059,7 @@ class CheckPointingTestCase(unittest.TestCase):
 
         # Set the image data by hand.
         key = "R00_S00_r.fits"
-        detname = "R00_S00"
+        detname = "R:0,0 S:0,0"
         detector = make_galsim_detector(camera_wrapper, detname,
                                         phot_params, obs_md)
         image = gs_interpreter.blankImage(detector=detector)

--- a/tests/testLSSTPlacement.py
+++ b/tests/testLSSTPlacement.py
@@ -126,10 +126,6 @@ class GalSimPlacementTest(unittest.TestCase):
                 ra_obj = ra_c + rng.random_sample()*0.2 - 0.1
                 dec_obj = dec_c + rng.random_sample()*0.2 - 0.1
 
-                dmx_wrong, dmy_wrong = pixelCoordsFromRaDec(ra_obj, dec_obj,
-                                                            chipName=detector.getName(),
-                                                            obs_metadata=obs,
-                                                            camera=self.camera)
 
                 dmx_pix, dmy_pix = pixelCoordsFromRaDec(ra_obj, dec_obj,
                                                         chipName=detector.getName(),
@@ -139,8 +135,6 @@ class GalSimPlacementTest(unittest.TestCase):
                 x_pix, y_pix = pixel_transformer.cameraPixFromDMPix(dmx_pix, dmy_pix,
                                                                     detector.getName())
 
-                x_pix_wrong, y_pix_wrong = pixel_transformer.cameraPixFromDMPix(dmx_wrong, dmy_wrong,
-                                                                                detector.getName())
 
                 d_ra = 3600.0*(ra_obj - obs.pointingRA)  # in arcseconds
                 d_dec = 3600.0*(dec_obj - obs.pointingDec)
@@ -166,11 +160,6 @@ class GalSimPlacementTest(unittest.TestCase):
                 x_centroid = sum([ii*im[:,ii].sum() for ii in range(im.shape[1])])/tot_flux
                 dd = np.sqrt((x_pix-x_centroid)**2 + (y_pix-y_centroid)**2)
                 self.assertLess(dd, 0.5*fwhm)
-
-                dd_wrong = np.sqrt((x_pix_wrong-x_centroid)**2 +
-                                   (y_pix_wrong-y_centroid)**2)
-
-                self.assertLess(dd, dd_wrong)
 
                 if os.path.exists(dbFileName):
                     os.unlink(dbFileName)

--- a/tests/testWcsUtils.py
+++ b/tests/testWcsUtils.py
@@ -28,7 +28,7 @@ class WcsTest(unittest.TestCase):
     def setUpClass(cls):
 
         cls.camera_wrapper = LSSTCameraWrapper()
-        cls.detector = cls.camera_wrapper.camera['R:1,1 S:2,2']
+        cls.detector = cls.camera_wrapper.camera['R11_S22']
 
         cls.obs = ObservationMetaData(pointingRA=25.0, pointingDec=-10.0,
                                       boundType='circle', boundLength=1.0,

--- a/ups/sims_GalSimInterface.table
+++ b/ups/sims_GalSimInterface.table
@@ -8,7 +8,7 @@ setupRequired(sims_coordUtils)
 setupRequired(sims_catalogs)
 setupRequired(sims_catUtils)
 
-setupOptional(obs_lsstSim)
+setupOptional(obs_lsst)
 
 #This is needed by the mssql python module
 envPrepend(TDSVER, 7.0)


### PR DESCRIPTION
@jchiang87 @cwwalter @jdswinbank 

This pull request should be merged when obs_lsstSim (or the lack thereof) causes lsst_sims to break.

Do not merge it beforehand, as it will delete (as opposed to replacing) functionality that currently depends on obs_lsstSim.

Jim, Chris: I cannot promise that the orientation of pixel x,y coordinates in sims_GalSimInterface will be correct after this gets merged. I think the obs_lsst PhosimMapper() actually respects the camera team coordinate system, the same way PhoSim does. All this branch does is make sure that tests pass and the code builds. Once obs_lsstSim is gone, ImSim should stop using the camera model in sims_GalSimInterface.