### PR TITLE
variable name bug-fix

### DIFF
--- a/python/lsst/sims/GalSimInterface/galSimInterpreter.py
+++ b/python/lsst/sims/GalSimInterface/galSimInterpreter.py
@@ -481,7 +481,7 @@ class GalSimInterpreter(object):
             centeredObj = centeredObj.rotate(gsObject.rotation_angle*galsim.degrees)
 
         # Apply weak lensing distortion.
-        centerObject = centeredObj.lens(gsObject.g1, gsObject.g2, gsObject.mu)
+        centeredObj = centeredObj.lens(gsObject.g1, gsObject.g2, gsObject.mu)
 
         # Apply the PSF
         if psf is not None:


### PR DESCRIPTION
Note that this change wouldn't affect DC2 Run3.0i simulations, since the Run3.0i instance catalogs set the weak lensing parameters all to zero for the FITS stamps.  